### PR TITLE
Add parsing TABLETS_ROUTING_V1 extension

### DIFF
--- a/src/Cassandra.Tests/Connections/TestHelpers/FakeSupportedOptionsInitializer.cs
+++ b/src/Cassandra.Tests/Connections/TestHelpers/FakeSupportedOptionsInitializer.cs
@@ -43,5 +43,11 @@ namespace Cassandra.Tests.Connections.TestHelpers
         {
             return null;
         }
+
+        public TabletInfo GetTabletInfo()
+        {
+            return null;
+
+        }
     }
 }

--- a/src/Cassandra/Connections/Connection.cs
+++ b/src/Cassandra/Connections/Connection.cs
@@ -577,6 +577,11 @@ namespace Cassandra.Connections
             return _supportedOptionsInitializer.GetShardingInfo();
         }
 
+        public TabletInfo TabletInfo()
+        {
+            return _supportedOptionsInitializer.GetTabletInfo();
+        }
+
         private void ReadHandler(byte[] buffer, int bytesReceived)
         {
             if (_isClosed)
@@ -853,7 +858,7 @@ namespace Cassandra.Connections
         /// </summary>
         private Task<Response> Startup()
         {
-            var request = _startupRequestFactory.CreateStartupRequest(Options);
+            var request = _startupRequestFactory.CreateStartupRequest(Options, _supportedOptionsInitializer);
             // Use the Connect timeout for the startup request timeout
             return Send(request, Configuration.SocketOptions.ConnectTimeoutMillis);
         }

--- a/src/Cassandra/Connections/Control/ISupportedOptionsInitializer.cs
+++ b/src/Cassandra/Connections/Control/ISupportedOptionsInitializer.cs
@@ -23,5 +23,6 @@ namespace Cassandra.Connections.Control
         Task ApplySupportedOptionsAsync(IConnection connection);
         void ApplySupportedFromResponse(Response response);
         ShardingInfo GetShardingInfo();
+        TabletInfo GetTabletInfo();
     }
 }

--- a/src/Cassandra/Connections/Control/SupportedOptionsInitializer.cs
+++ b/src/Cassandra/Connections/Control/SupportedOptionsInitializer.cs
@@ -37,6 +37,7 @@ namespace Cassandra.Connections.Control
         private const string ScyllaShardAwarePortSSL = "SCYLLA_SHARD_AWARE_PORT_SSL";
 
         private ShardingInfo _shardingInfo;
+        private TabletInfo _tabletInfo;
 
         public SupportedOptionsInitializer(Metadata metadata)
         {
@@ -65,11 +66,17 @@ namespace Cassandra.Connections.Control
 
             ApplyProductTypeOption(supportedResponse.Output.Options);
             ApplyScyllaShardingOption(supportedResponse.Output.Options);
+            ApplyScyllaTabletOption(supportedResponse.Output.Options);
         }
 
         public ShardingInfo GetShardingInfo()
         {
             return _shardingInfo;
+        }
+
+        public TabletInfo GetTabletInfo()
+        {
+            return _tabletInfo;
         }
 
         private void ApplyProductTypeOption(IDictionary<string, string[]> options)
@@ -88,6 +95,11 @@ namespace Cassandra.Connections.Control
             {
                 _metadata.SetProductTypeAsDbaas();
             }
+        }
+
+        private void ApplyScyllaTabletOption(IDictionary<string, string[]> options)
+        {
+            _tabletInfo = TabletInfo.ParseTabletInfo(options);
         }
 
         private void ApplyScyllaShardingOption(IDictionary<string, string[]> options)

--- a/src/Cassandra/Connections/TabletInfo.cs
+++ b/src/Cassandra/Connections/TabletInfo.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+
+namespace Cassandra.Connections
+{
+    public class TabletInfo
+    {
+        private const string SCYLLA_TABLETS_STARTUP_OPTION_KEY = "TABLETS_ROUTING_V1";
+        private const string SCYLLA_TABLETS_STARTUP_OPTION_VALUE = "";
+        public const string TABLETS_ROUTING_V1_CUSTOM_PAYLOAD_KEY = "tablets-routing-v1";
+
+        private bool enabled;
+
+        private TabletInfo(bool enabled)
+        {
+            this.enabled = enabled;
+        }
+
+        // Currently pertains only to TABLETS_ROUTING_V1
+        public bool IsEnabled()
+        {
+            return enabled;
+        }
+
+        public static TabletInfo ParseTabletInfo(IDictionary<string, string[]> supported)
+        {
+            if (supported.TryGetValue(SCYLLA_TABLETS_STARTUP_OPTION_KEY, out var values))
+            {
+                return new TabletInfo(
+                    values != null &&
+                    values.Length == 1 &&
+                    values[0] == SCYLLA_TABLETS_STARTUP_OPTION_VALUE
+                );
+            }
+
+            return new TabletInfo(false);
+        }
+    }
+}

--- a/src/Cassandra/Requests/IStartupOptionsFactory.cs
+++ b/src/Cassandra/Requests/IStartupOptionsFactory.cs
@@ -15,11 +15,12 @@
 //
 
 using System.Collections.Generic;
+using Cassandra.Connections.Control;
 
 namespace Cassandra.Requests
 {
     internal interface IStartupOptionsFactory
     {
-        IReadOnlyDictionary<string, string> CreateStartupOptions(ProtocolOptions options);
+        IReadOnlyDictionary<string, string> CreateStartupOptions(ProtocolOptions options, ISupportedOptionsInitializer supportedOptionsInitializer);
     }
 }

--- a/src/Cassandra/Requests/IStartupRequestFactory.cs
+++ b/src/Cassandra/Requests/IStartupRequestFactory.cs
@@ -14,10 +14,12 @@
 //   limitations under the License.
 //
 
+using Cassandra.Connections.Control;
+
 namespace Cassandra.Requests
 {
     internal interface IStartupRequestFactory
     {
-        IRequest CreateStartupRequest(ProtocolOptions protocolOptions);
+        IRequest CreateStartupRequest(ProtocolOptions protocolOptions, ISupportedOptionsInitializer supportedOptionsInitializer);
     }
 }

--- a/src/Cassandra/Requests/StartupOptionsFactory.cs
+++ b/src/Cassandra/Requests/StartupOptionsFactory.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using Cassandra.Helpers;
+using Cassandra.Connections.Control;
 
 namespace Cassandra.Requests
 {
@@ -31,6 +32,7 @@ namespace Cassandra.Requests
         public const string ApplicationNameOption = "APPLICATION_NAME";
         public const string ApplicationVersionOption = "APPLICATION_VERSION";
         public const string ClientIdOption = "CLIENT_ID";
+        public const string TabletsRoutingV1Option = "TABLETS_ROUTING_V1";
 
         public const string CqlVersion = "3.0.0";
         public const string SnappyCompression = "snappy";
@@ -47,7 +49,7 @@ namespace Cassandra.Requests
             _clusterId = clusterId;
         }
 
-        public IReadOnlyDictionary<string, string> CreateStartupOptions(ProtocolOptions options)
+        public IReadOnlyDictionary<string, string> CreateStartupOptions(ProtocolOptions options, ISupportedOptionsInitializer supportedOptionsInitializer = null)
         {
             var startupOptions = new Dictionary<string, string>
             {
@@ -73,6 +75,11 @@ namespace Cassandra.Requests
             if (options.NoCompact)
             {
                 startupOptions.Add(StartupOptionsFactory.NoCompactOption, "true");
+            }
+
+            if (supportedOptionsInitializer?.GetTabletInfo() != null && supportedOptionsInitializer.GetTabletInfo().IsEnabled())
+            {
+                startupOptions.Add(StartupOptionsFactory.TabletsRoutingV1Option, "true");
             }
 
             startupOptions.Add(StartupOptionsFactory.DriverNameOption, AssemblyHelpers.GetAssemblyTitle(typeof(StartupOptionsFactory)));

--- a/src/Cassandra/Requests/StartupRequestFactory.cs
+++ b/src/Cassandra/Requests/StartupRequestFactory.cs
@@ -14,6 +14,8 @@
 //   limitations under the License.
 //
 
+using Cassandra.Connections.Control;
+
 namespace Cassandra.Requests
 {
     internal class StartupRequestFactory : IStartupRequestFactory
@@ -25,9 +27,9 @@ namespace Cassandra.Requests
             _optionsFactory = optionsFactory;
         }
 
-        public IRequest CreateStartupRequest(ProtocolOptions protocolOptions)
+        public IRequest CreateStartupRequest(ProtocolOptions protocolOptions, ISupportedOptionsInitializer supportedOptionsInitializer)
         {
-            return new StartupRequest(_optionsFactory.CreateStartupOptions(protocolOptions));
+            return new StartupRequest(_optionsFactory.CreateStartupOptions(protocolOptions, supportedOptionsInitializer));
         }
     }
 }


### PR DESCRIPTION
In order for Scylla to send the tablet info, the driver must tell
the database during connection handshake that it is able to
interpret it.

Fixes: #11 