### PR TITLE
Change version to 3.22.0.1

### DIFF
--- a/src/Cassandra/Cassandra.csproj
+++ b/src/Cassandra/Cassandra.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>ScyllaDB C# Driver for Scylla</AssemblyTitle>
     <AssemblyVersion>3.99.0.0</AssemblyVersion>
     <FileVersion>3.22.0.0</FileVersion>
-    <VersionPrefix>3.22.0</VersionPrefix>
+    <VersionPrefix>3.22.0.1</VersionPrefix>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <Authors>DataStax and ScyllaDB</Authors>
     <TargetFrameworks Condition="'$(BuildCoreOnly)' != 'True'">net452;netstandard2.0</TargetFrameworks>
@@ -19,7 +19,7 @@
     <AssemblyOriginatorKeyFile>../../build/scylladb.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PackageId>ScyllaDBCSharpDriver</PackageId>
-    <Version>3.22.0.0</Version>
+    <Version>3.22.0.1</Version>
     <Title>ScyllaDB C# Driver for Scylla</Title>
     <PackageTags>driver;client;database;nosql;dotnet;netcore;db;scylla;scylladb</PackageTags>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>

--- a/src/Extensions/Cassandra.AppMetrics/Cassandra.AppMetrics.csproj
+++ b/src/Extensions/Cassandra.AppMetrics/Cassandra.AppMetrics.csproj
@@ -5,7 +5,7 @@
     <Copyright>Copyright © by DataStax and ScyllaDB</Copyright>
     <AssemblyVersion>3.99.0.0</AssemblyVersion>
     <FileVersion>3.22.0.0</FileVersion>
-    <VersionPrefix>3.22.0</VersionPrefix>
+    <VersionPrefix>3.22.0.1</VersionPrefix>
     <Authors>DataStax and ScyllaDB</Authors>
     <TargetFrameworks Condition="'$(BuildCoreOnly)' != 'True'">netstandard2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition="'$(BuildCoreOnly)' == 'True'">netstandard2.0</TargetFrameworks>
@@ -17,7 +17,7 @@
     <AssemblyOriginatorKeyFile>../../../build/scylladb.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PackageId>ScyllaDBCSharpDriver.AppMetrics</PackageId>
-    <Version>3.22.0.0</Version>
+    <Version>3.22.0.1</Version>
     <Title>ScyllaDB C# Drivers App Metrics Extension</Title>
     <PackageTags>scylladb;scylla;driver;client;metrics;appmetricsdatabase;nosql;dotnet;netcore;db</PackageTags>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>

--- a/src/Extensions/Cassandra.OpenTelemetry/Cassandra.OpenTelemetry.csproj
+++ b/src/Extensions/Cassandra.OpenTelemetry/Cassandra.OpenTelemetry.csproj
@@ -5,7 +5,7 @@
     <Copyright>Copyright © by DataStax and ScyllaDB</Copyright>
     <AssemblyVersion>3.99.0.0</AssemblyVersion>
     <FileVersion>3.22.0.0</FileVersion>
-    <VersionPrefix>3.22.0</VersionPrefix>
+    <VersionPrefix>3.22.0.1</VersionPrefix>
     <Authors>DataStax and ScyllaDB</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -15,7 +15,7 @@
     <AssemblyOriginatorKeyFile>../../../build/scylladb.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
     <PackageId>ScyllaDBCSharpDriver.OpenTelemetry</PackageId>
-    <Version>3.22.0.0</Version>
+    <Version>3.22.0.1</Version>
     <Title>ScyllaDB C# Drivers OpenTelemetry Extension</Title>
     <PackageTags>scylladb;scylla;driver;client;opentelemetry;tracing;instrumentation;nosql;dotnet;netcore;db</PackageTags>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>


### PR DESCRIPTION
3.22.0.0 is the same as 3.22.0 and we want to have a new version for Scylla