### PR TITLE
doc: add the API reference page

### DIFF
--- a/docs/source/datastax-api-reference.md
+++ b/docs/source/datastax-api-reference.md
@@ -1,0 +1,8 @@
+# API Reference
+
+The ScyllaDB C# driver is a fork of DataStax C# driver, which includes some
+non-breaking changes for ScyllaDB optimization.
+
+You can use the DataStax API reference to work with the ScyllaDB C# driver:
+
+[C# Driver API Reference ](https://docs.datastax.com/en/drivers/csharp/3.22/api/Cassandra.html)

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -7,8 +7,10 @@ ScyllaDB's fork of a modern, feature-rich and highly tunable C# client library f
 :hidden:
 :maxdepth: 1
 
+
 features/index
 faq/index
 upgrade-guide/index
 examples/index
+datastax-api-reference.md
 :::


### PR DESCRIPTION
This commit adds the API reference  page, which includes a link to the DataStax API documentation for the C# driver.

This is a workaround before we implement a solution to publish API reference documentation to our site.