### PR TITLE
doc: set version 3.22 as latest

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,12 +11,12 @@ from sphinx_scylladb_theme.utils import multiversion_regex_builder
 # Builds documentation for the following tags and branches.
 TAGS = []
 BRANCHES = [
-    "master",
+    "master", "3.22",
 ]
 # Sets the latest version.
-LATEST_VERSION = "master"
+LATEST_VERSION = "3.22"
 # Set which versions are not released yet.
-UNSTABLE_VERSIONS = []
+UNSTABLE_VERSIONS = ["master"]
 # Set which versions are deprecated
 DEPRECATED_VERSIONS = [""]
 # Sets custom build.


### PR DESCRIPTION
This PR configures the driver versions for which documentation is published at https://csharp-driver.docs.scylladb.com/.

- It enables publication for version 3.22.
- It specifies 3.22 as the latest stable version to be published at https://csharp-driver.docs.scylladb.com/stable/.
- It moves the master branch to the list of unstable versions.

Fixes https://github.com/scylladb/csharp-driver/issues/77

DO NOT BACKPORT