### PR TITLE
doc: set version 3.22.0.1 as latest

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,12 +9,12 @@ from sphinx_scylladb_theme.utils import multiversion_regex_builder
 # -- Global variables
 
 # Builds documentation for the following tags and branches.
-TAGS = []
+TAGS = ["3.22.0.1"]
 BRANCHES = [
-    "master", "3.22",
+    "master",
 ]
 # Sets the latest version.
-LATEST_VERSION = "3.22"
+LATEST_VERSION = "3.22.0.1"
 # Set which versions are not released yet.
 UNSTABLE_VERSIONS = ["master"]
 # Set which versions are deprecated


### PR DESCRIPTION
This PR enables publishing the docs for version 3.22.0.1 by adding a tag, and sets it as the latest stable version.

Fixes https://github.com/scylladb/csharp-driver/issues/77