### PR TITLE
Make driver use `where key='local'` for every select from `system.local`

### DIFF
--- a/examples/OpenTelemetry/Exporter/ConsoleExporter/Program.cs
+++ b/examples/OpenTelemetry/Exporter/ConsoleExporter/Program.cs
@@ -59,7 +59,7 @@ namespace ConsoleExporter
                 {
                     try
                     {
-                        var x = await session.ExecuteAsync(new SimpleStatement("SELECT * FROM system.local"));
+                        var x = await session.ExecuteAsync(new SimpleStatement("SELECT key FROM system.local WHERE key='local'"));
                     }
                     catch (Exception ex)
                     {

--- a/examples/SecureConnectionBundle/MinimalExample/Program.cs
+++ b/examples/SecureConnectionBundle/MinimalExample/Program.cs
@@ -40,7 +40,7 @@ namespace MinimalExample
                     .Build()
                     .Connect();
 
-            var rowSet = session.Execute("select * from system.local");
+            var rowSet = session.Execute("SELECT * FROM system.local WHERE key='local'");
             Console.WriteLine(rowSet.First().GetValue<string>("cluster_name"));
 
             Console.WriteLine("Press enter to exit.");

--- a/src/Cassandra.IntegrationTests/Ado/AdoBasicTests.cs
+++ b/src/Cassandra.IntegrationTests/Ado/AdoBasicTests.cs
@@ -117,14 +117,14 @@ namespace Cassandra.IntegrationTests.Data
             var cmd3 = _connection.CreateCommand();
 
             TestCluster.PrimeFluent(
-                b => b.WhenQuery("SELECT key FROM system.local")
+                b => b.WhenQuery("SELECT key FROM system.local WHERE key='local'")
                       .ThenRowsSuccess(new[] { "key" }, r => r.WithRow("local")));
 
             TestCluster.PrimeFluent(
                 b => b.WhenQuery("SELECT * FROM system.local WHERE key = 'does not exist'")
                       .ThenVoidSuccess());
 
-            cmd1.CommandText = "SELECT key FROM system.local";
+            cmd1.CommandText = "SELECT key FROM system.local WHERE key='local'";
             cmd3.CommandText = "SELECT * FROM system.local WHERE key = 'does not exist'";
             Assert.IsInstanceOf<string>(cmd1.ExecuteScalar());
             Assert.IsNull(cmd3.ExecuteScalar());

--- a/src/Cassandra.IntegrationTests/Core/ClientWarningsTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ClientWarningsTests.cs
@@ -78,7 +78,7 @@ namespace Cassandra.IntegrationTests.Core
         [Test]
         public void Should_QueryTrace_When_Enabled()
         {
-            var rs = Session.Execute(new SimpleStatement("SELECT * from system.local").EnableTracing());
+            var rs = Session.Execute(new SimpleStatement("SELECT * FROM system.local WHERE key='local'").EnableTracing());
             Assert.NotNull(rs.Info.QueryTrace);
             var hosts = Session.Cluster.AllHosts();
             Assert.NotNull(hosts);
@@ -99,14 +99,14 @@ namespace Cassandra.IntegrationTests.Core
         [Test]
         public void Should_NotGetQueryTrace_When_NotEnabledXDefaultX()
         {
-            var rs = Session.Execute(new SimpleStatement("SELECT * from system.local"));
+            var rs = Session.Execute(new SimpleStatement("SELECT * FROM system.local WHERE key='local'"));
             Assert.Null(rs.Info.QueryTrace);
         }
 
         [Test, TestCassandraVersion(2, 2)]
         public void Should_NotGenerateWarning_When_RegularBehavior()
         {
-            var rs = Session.Execute("SELECT * FROM system.local");
+            var rs = Session.Execute("SELECT * FROM system.local WHERE key='local'");
             //It should be null for queries that do not generate warnings
             Assert.Null(rs.Info.Warnings);
         }

--- a/src/Cassandra.IntegrationTests/Core/ClusterSimulacronTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ClusterSimulacronTests.cs
@@ -117,7 +117,7 @@ namespace Cassandra.IntegrationTests.Core
                 Assert.DoesNotThrow(() =>
                 {
                     var session = cluster.Connect();
-                    session.Execute("select * from system.local");
+                    session.Execute("SELECT * FROM system.local WHERE key='local'");
                 });
             }
         }
@@ -131,7 +131,7 @@ namespace Cassandra.IntegrationTests.Core
                                         .Build())
             {
                 var session = cluster.Connect();
-                session.Execute("select * from system.local");
+                session.Execute("SELECT * FROM system.local WHERE key='local'");
                 Assert.That(cluster.AllHosts().Count, Is.EqualTo(3));
             }
         }

--- a/src/Cassandra.IntegrationTests/Core/ClusterTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ClusterTests.cs
@@ -178,7 +178,7 @@ namespace Cassandra.IntegrationTests.Core
 
                 TestHelper.RetryAssert(() =>
                     {
-                        var rs = session.Execute("SELECT key FROM system.local");
+                        var rs = session.Execute("SELECT key FROM system.local WHERE key='local'");
                         Assert.True(rs.Info.QueriedHost.Address.ToString() == newNodeAddress, "Newly bootstrapped node should be queried");
                     },
                     1,
@@ -218,7 +218,7 @@ namespace Cassandra.IntegrationTests.Core
                 var queried = false;
                 for (var i = 0; i < 10; i++)
                 {
-                    var rs = session.Execute("SELECT key FROM system.local");
+                    var rs = session.Execute("SELECT key FROM system.local WHERE key='local'");
                     if (rs.Info.QueriedHost.Address.ToString() == decommisionedNode)
                     {
                         queried = true;

--- a/src/Cassandra.IntegrationTests/Core/ConnectionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ConnectionTests.cs
@@ -45,7 +45,7 @@ namespace Cassandra.IntegrationTests.Core
     [TestTimeout(600000), Category(TestCategory.Short), Category(TestCategory.RealCluster)]
     public class ConnectionTests : TestGlobals
     {
-        private const string BasicQuery = "SELECT key FROM system.local";
+        private const string BasicQuery = "SELECT key FROM system.local WHERE key='local'";
         private ITestCluster _testCluster;
 
         [OneTimeSetUp]
@@ -184,7 +184,7 @@ namespace Cassandra.IntegrationTests.Core
                 connection.Open().Wait();
 
                 //Start a query
-                var task = Query(connection, "SELECT * FROM system.local", QueryProtocolOptions.Default);
+                var task = Query(connection, "SELECT * FROM system.local WHERE key='local'", QueryProtocolOptions.Default);
                 task.Wait(360000);
                 Assert.AreEqual(TaskStatus.RanToCompletion, task.Status);
                 var output = ValidateResult<OutputRows>(task.Result);
@@ -208,7 +208,7 @@ namespace Cassandra.IntegrationTests.Core
                 {
                     //schema_columns
                     // ReSharper disable once AccessToDisposedClosure
-                    tasks[i] = Task.Factory.StartNew(() => Query(connection, "SELECT * FROM system.local", QueryProtocolOptions.Default)).Unwrap();
+                    tasks[i] = Task.Factory.StartNew(() => Query(connection, "SELECT * FROM system.local WHERE key='local'", QueryProtocolOptions.Default)).Unwrap();
                 }
                 // ReSharper disable once CoVariantArrayConversion
                 Task.WaitAll(tasks);
@@ -329,7 +329,7 @@ namespace Cassandra.IntegrationTests.Core
                 //Run a query multiple times
                 for (var i = 0; i < 8; i++)
                 {
-                    var task = Query(connection, "SELECT * FROM system.local", QueryProtocolOptions.Default);
+                    var task = Query(connection, "SELECT * FROM system.local WHERE key='local'", QueryProtocolOptions.Default);
                     task.Wait(1000);
                     Assert.AreEqual(TaskStatus.RanToCompletion, task.Status);
                     Assert.NotNull(task.Result);
@@ -409,7 +409,7 @@ namespace Cassandra.IntegrationTests.Core
             using (var connection = CreateConnection())
             {
                 connection.Open().Wait();
-                const string query = "SELECT * FROM system.local";
+                const string query = "SELECT * FROM system.local WHERE key='local'";
                 Query(connection, query).
                     ContinueWith((t) =>
                     {
@@ -430,13 +430,13 @@ namespace Cassandra.IntegrationTests.Core
                 //Run the query multiple times
                 for (var i = 0; i < 129; i++)
                 {
-                    taskList.Add(Query(connection, "SELECT * FROM system.local", QueryProtocolOptions.Default));
+                    taskList.Add(Query(connection, "SELECT * FROM system.local WHERE key='local'", QueryProtocolOptions.Default));
                 }
                 Task.WaitAll(taskList.ToArray());
                 Assert.True(taskList.All(t => t.Status == TaskStatus.RanToCompletion), "Not all task completed");
 
                 //One last time
-                var task = Query(connection, "SELECT * FROM system.local");
+                var task = Query(connection, "SELECT * FROM system.local WHERE key='local'");
                 Assert.True(task.Result != null);
             }
         }
@@ -506,7 +506,7 @@ namespace Cassandra.IntegrationTests.Core
                 //The keyspace should still be null
                 Assert.Null(connection.Keyspace);
                 //Execute a query WITH the keyspace prefix still works
-                TaskHelper.WaitToComplete(Query(connection, "SELECT * FROM system.local", QueryProtocolOptions.Default));
+                TaskHelper.WaitToComplete(Query(connection, "SELECT * FROM system.local WHERE key='local'", QueryProtocolOptions.Default));
             }
         }
 
@@ -683,7 +683,7 @@ namespace Cassandra.IntegrationTests.Core
                 var taskList = new List<Task<Response>>();
                 for (var i = 0; i < 1024; i++)
                 {
-                    taskList.Add(Query(connection, "SELECT * FROM system.local"));
+                    taskList.Add(Query(connection, "SELECT * FROM system.local WHERE key='local'"));
                 }
                 for (var i = 0; i < 1000; i++)
                 {
@@ -711,7 +711,7 @@ namespace Cassandra.IntegrationTests.Core
                 await Task.Delay(1000).ConfigureAwait(false);
 
                 //A new call to write will be called back immediately with an exception
-                Assert.ThrowsAsync<SocketException>(async () => await Query(connection, "SELECT * FROM system.local").ConfigureAwait(false));
+                Assert.ThrowsAsync<SocketException>(async () => await Query(connection, "SELECT * FROM system.local WHERE key='local'").ConfigureAwait(false));
             }
         }
 
@@ -738,7 +738,7 @@ namespace Cassandra.IntegrationTests.Core
             {
                 await connection.Open().ConfigureAwait(false);
                 // Execute a dummy query
-                await Query(connection, "SELECT * FROM system.local", QueryProtocolOptions.Default)
+                await Query(connection, "SELECT * FROM system.local WHERE key='local'", QueryProtocolOptions.Default)
                     .ConfigureAwait(false);
 
                 var writeCounter = 0;
@@ -755,7 +755,7 @@ namespace Cassandra.IntegrationTests.Core
             {
                 await connection.Open().ConfigureAwait(false);
                 //execute a dummy query
-                await Query(connection, "SELECT * FROM system.local", QueryProtocolOptions.Default)
+                await Query(connection, "SELECT * FROM system.local WHERE key='local'", QueryProtocolOptions.Default)
                     .ConfigureAwait(false);
                 await Task.Delay(500).ConfigureAwait(false);
                 var writeCounter = 0;
@@ -789,7 +789,7 @@ namespace Cassandra.IntegrationTests.Core
                 Assert.AreEqual(defaultHeartbeatInterval, connection.Configuration.PoolingOptions.GetHeartBeatInterval());
 
                 //execute a dummy query
-                await Query(connection, "SELECT * FROM system.local", QueryProtocolOptions.Default).ConfigureAwait(false);
+                await Query(connection, "SELECT * FROM system.local WHERE key='local'", QueryProtocolOptions.Default).ConfigureAwait(false);
 
                 await TestHelper.RetryAssertAsync(async () =>
                 {

--- a/src/Cassandra.IntegrationTests/Core/ControlConnectionSimulatorTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ControlConnectionSimulatorTests.cs
@@ -53,7 +53,7 @@ namespace Cassandra.IntegrationTests.Core
                 if (version > ProtocolVersion.V2)
                 {
                     var session = cluster.Connect();
-                    Parallel.For(0, 10, _ => session.Execute("SELECT * FROM system.local"));
+                    Parallel.For(0, 10, _ => session.Execute("SELECT * FROM system.local WHERE key='local'"));
                     Assert.AreEqual(version, cluster.InternalRef.GetControlConnection().ProtocolVersion);
                 }
                 else
@@ -80,7 +80,7 @@ namespace Cassandra.IntegrationTests.Core
             using (var cluster = ClusterBuilder().WithBetaProtocolVersions().AddContactPoint(testCluster.InitialContactPoint).Build())
             {
                 var session = cluster.Connect();
-                Parallel.For(0, 10, _ => session.Execute("SELECT * FROM system.local"));
+                Parallel.For(0, 10, _ => session.Execute("SELECT * FROM system.local WHERE key='local'"));
                 Assert.AreEqual(version, cluster.InternalRef.GetControlConnection().ProtocolVersion);
             }
         }

--- a/src/Cassandra.IntegrationTests/Core/CustomPayloadTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/CustomPayloadTests.cs
@@ -54,7 +54,7 @@ namespace Cassandra.IntegrationTests.Core
         public void Query_Payload_Test()
         {
             var outgoing = new Dictionary<string, byte[]> { { "k1", Encoding.UTF8.GetBytes("value1") }, { "k2", Encoding.UTF8.GetBytes("value2") } };
-            var stmt = new SimpleStatement("SELECT * FROM system.local");
+            var stmt = new SimpleStatement("SELECT * FROM system.local WHERE key='local'");
             stmt.SetOutgoingPayload(outgoing);
             var rs = Session.Execute(stmt);
             Assert.NotNull(rs.Info.IncomingPayload);

--- a/src/Cassandra.IntegrationTests/Core/MetadataTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/MetadataTests.cs
@@ -158,12 +158,12 @@ namespace Cassandra.IntegrationTests.Core
             }
             testCluster.Stop(hostToKill);
             Thread.Sleep(10000);
-            TestHelper.Invoke(() => session.Execute("SELECT key from system.local"), 10);
+            TestHelper.Invoke(() => session.Execute("SELECT key FROM system.local WHERE key='local'"), 10);
             Assert.True(cluster.AllHosts().Any(h => TestHelper.GetLastAddressByte(h) == hostToKill && !h.IsUp));
             Assert.True(downEventFired);
             testCluster.Start(hostToKill);
             Thread.Sleep(20000);
-            TestHelper.Invoke(() => session.Execute("SELECT key from system.local"), 10);
+            TestHelper.Invoke(() => session.Execute("SELECT key FROM system.local WHERE key='local'"), 10);
             Assert.True(cluster.AllHosts().All(h => h.IsConsiderablyUp));
             //When the host of the control connection is used
             //It can result that event UP is not fired as it is not received by the control connection (it reconnected but missed the event) 
@@ -522,7 +522,7 @@ namespace Cassandra.IntegrationTests.Core
             {
                 var session = cluster.Connect();
                 //warm up the pool
-                TestHelper.Invoke(() => session.Execute("SELECT key from system.local"), 10);
+                TestHelper.Invoke(() => session.Execute("SELECT key FROM system.local WHERE key='local'"), 10);
                 foreach (var q in queries)
                 {
                     Assert.DoesNotThrow(() => session.Execute(q));

--- a/src/Cassandra.IntegrationTests/Core/ParameterizedStatementsTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ParameterizedStatementsTests.cs
@@ -527,7 +527,7 @@ namespace Cassandra.IntegrationTests.Core
             }
 
             // It defaults to null
-            Assert.Null(new SimpleStatement("SELECT key FROM system.local").Keyspace);
+            Assert.Null(new SimpleStatement("SELECT key FROM system.local WHERE key='local'").Keyspace);
 
             var statement = new SimpleStatement("SELECT key FROM local").SetKeyspace("system");
             Assert.AreEqual("system", statement.Keyspace);

--- a/src/Cassandra.IntegrationTests/Core/PoolShortTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PoolShortTests.cs
@@ -244,7 +244,7 @@ namespace Cassandra.IntegrationTests.Core
                     Assert.DoesNotThrow(() =>
                     {
                         var session = cluster.Connect();
-                        TestHelper.Invoke(() => session.Execute("select * from system.local"), 10);
+                        TestHelper.Invoke(() => session.Execute("SELECT * FROM system.local WHERE key='local'"), 10);
                     });
                 }
 #pragma warning restore SYSLIB0039 // Type or member is obsolete
@@ -326,7 +326,7 @@ namespace Cassandra.IntegrationTests.Core
                 var allHosts = cluster.AllHosts();
                 Assert.AreEqual(3, allHosts.Count);
                 await TestHelper.TimesLimit(() =>
-                    session.ExecuteAsync(new SimpleStatement("SELECT * FROM system.local")), 100, 16).ConfigureAwait(false);
+                    session.ExecuteAsync(new SimpleStatement("SELECT * FROM system.local WHERE key='local'")), 100, 16).ConfigureAwait(false);
 
                 // 1 per hosts + control connection
                 await TestHelper.RetryAssertAsync(async () =>
@@ -380,7 +380,7 @@ namespace Cassandra.IntegrationTests.Core
                     var allHosts = cluster.AllHosts();
                     Assert.AreEqual(3, allHosts.Count);
                     await TestHelper.TimesLimit(() =>
-                        session.ExecuteAsync(new SimpleStatement("SELECT * FROM system.local")), 100, 16).ConfigureAwait(false);
+                        session.ExecuteAsync(new SimpleStatement("SELECT * FROM system.local WHERE key='local'")), 100, 16).ConfigureAwait(false);
 
                     var serverConnections = await testCluster.GetConnectedPortsAsync().ConfigureAwait(false);
                     // 1 per hosts + control connection
@@ -427,7 +427,7 @@ namespace Cassandra.IntegrationTests.Core
 
                     TestHelper.RetryAssert(() =>
                     {
-                        Assert.DoesNotThrowAsync(() => cluster.InternalRef.GetControlConnection().QueryAsync("SELECT * FROM system.local"));
+                        Assert.DoesNotThrowAsync(() => cluster.InternalRef.GetControlConnection().QueryAsync("SELECT * FROM system.local WHERE key='local'"));
                     }, 100, 100);
                 }
 
@@ -513,7 +513,7 @@ namespace Cassandra.IntegrationTests.Core
                 var hosts = cluster.AllHosts().ToArray();
 
                 await TestHelper.TimesLimit(() =>
-                    session.ExecuteAsync(new SimpleStatement("SELECT key FROM system.local")), 100, 16).ConfigureAwait(false);
+                    session.ExecuteAsync(new SimpleStatement("SELECT key FROM system.local WHERE key='local'")), 100, 16).ConfigureAwait(false);
 
                 // Wait until all connections to all host are created
                 await TestHelper.WaitUntilAsync(() =>
@@ -570,7 +570,7 @@ namespace Cassandra.IntegrationTests.Core
         [Test]
         public async Task Should_Use_Single_Host_When_Configured_At_Statement_Level()
         {
-            const string query = "SELECT * FROM system.local";
+            const string query = "SELECT * FROM system.local WHERE key='local'";
             var builder = ClusterBuilder().WithLoadBalancingPolicy(new TestHelper.OrderedLoadBalancingPolicy());
 
             using (var testCluster = SimulacronCluster.CreateNew(new SimulacronOptions { Nodes = "3" }))
@@ -603,7 +603,7 @@ namespace Cassandra.IntegrationTests.Core
         [Test]
         public void Should_Throw_NoHostAvailableException_When_Targeting_Single_Ignored_Host()
         {
-            const string query = "SELECT * FROM system.local";
+            const string query = "SELECT * FROM system.local WHERE key='local'";
             // Mark the last host as ignored
             var lbp = new TestHelper.CustomLoadBalancingPolicy(
                 (cluster, ks, stmt) => cluster.AllHosts(),
@@ -678,7 +678,7 @@ namespace Cassandra.IntegrationTests.Core
 
                 Parallel.For(0, 10, _ =>
                 {
-                    var statement = new SimpleStatement("SELECT * FROM system.local").SetHost(lastHost)
+                    var statement = new SimpleStatement("SELECT * FROM system.local WHERE key='local'").SetHost(lastHost)
                                                                                      .SetIdempotence(true);
 
                     var ex = Assert.ThrowsAsync<NoHostAvailableException>(() => session.ExecuteAsync(statement));
@@ -734,7 +734,7 @@ namespace Cassandra.IntegrationTests.Core
 
                 await TestHelper.TimesLimit(() =>
                 {
-                    var statement = new SimpleStatement("SELECT * FROM system.local").SetHost(host);
+                    var statement = new SimpleStatement("SELECT * FROM system.local WHERE key='local'").SetHost(host);
                     return session.ExecuteAsync(statement);
                 }, 1, 1).ConfigureAwait(false);
 

--- a/src/Cassandra.IntegrationTests/Core/PoolTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PoolTests.cs
@@ -66,7 +66,7 @@ namespace Cassandra.IntegrationTests.Core
                 DateTime futureDateTime = DateTime.Now.AddSeconds(120);
                 while ((from singleHost in queriedHosts select singleHost).Distinct().Count() < 4 && DateTime.Now < futureDateTime)
                 {
-                    var rs = session.Execute("SELECT * FROM system.local");
+                    var rs = session.Execute("SELECT * FROM system.local WHERE key='local'");
                     queriedHosts.Add(rs.Info.QueriedHost.ToString());
                     Thread.Sleep(50);
                 }
@@ -75,7 +75,7 @@ namespace Cassandra.IntegrationTests.Core
                 // Create List of actions
                 Action selectAction = () =>
                 {
-                    var rs = session.Execute("SELECT * FROM system.local");
+                    var rs = session.Execute("SELECT * FROM system.local WHERE key='local'");
                     Assert.Greater(rs.Count(), 0);
                 };
                 var actions = new List<Action>();
@@ -100,7 +100,7 @@ namespace Cassandra.IntegrationTests.Core
                 // Execute some more SELECTs
                 for (var i = 0; i < 250; i++)
                 {
-                    var rowSet2 = session.Execute("SELECT * FROM system.local");
+                    var rowSet2 = session.Execute("SELECT * FROM system.local WHERE key='local'");
                     Assert.Greater(rowSet2.Count(), 0);
                     StringAssert.StartsWith(nonShareableTestCluster.ClusterIpPrefix + "4", rowSet2.Info.QueriedHost.ToString());
                 }
@@ -129,7 +129,7 @@ namespace Cassandra.IntegrationTests.Core
                 DateTime futureDateTime = DateTime.Now.AddSeconds(120);
                 while ((from singleHost in queriedHosts select singleHost).Distinct().Count() < 4 && DateTime.Now < futureDateTime)
                 {
-                    var rs = session.Execute("SELECT * FROM system.local");
+                    var rs = session.Execute("SELECT * FROM system.local WHERE key='local'");
                     queriedHosts.Add(rs.Info.QueriedHost.ToString());
                     Thread.Sleep(50);
                 }
@@ -138,7 +138,7 @@ namespace Cassandra.IntegrationTests.Core
                 // Create list of actions
                 Action selectAction = () =>
                 {
-                    var rs = session.Execute("SELECT * FROM system.local");
+                    var rs = session.Execute("SELECT * FROM system.local WHERE key='local'");
                     Assert.Greater(rs.Count(), 0);
                 };
                 var actions = new List<Action>();
@@ -188,7 +188,7 @@ namespace Cassandra.IntegrationTests.Core
                     futureDateTime = DateTime.Now.AddSeconds(120);
                     while ((from singleHost in queriedHosts select singleHost).Distinct().Count() < 4 && DateTime.Now < futureDateTime)
                     {
-                        var rs = session.Execute("SELECT * FROM system.local");
+                        var rs = session.Execute("SELECT * FROM system.local WHERE key='local'");
                         queriedHosts.Add(rs.Info.QueriedHost.ToString());
                         Thread.Sleep(50);
                     }
@@ -226,7 +226,7 @@ namespace Cassandra.IntegrationTests.Core
             };
             nonShareableTestCluster.Stop(2);
             var session = cluster.Connect();
-            TestHelper.Invoke(() => session.Execute("SELECT * FROM system.local"), 10);
+            TestHelper.Invoke(() => session.Execute("SELECT * FROM system.local WHERE key='local'"), 10);
             Assert.AreEqual(1, connectionAttempts);
             var watch = new Stopwatch();
             watch.Start();
@@ -234,7 +234,7 @@ namespace Cassandra.IntegrationTests.Core
             {
                 if (watch.ElapsedMilliseconds < waitTime)
                 {
-                    session.ExecuteAsync(new SimpleStatement("SELECT * FROM system.local"));
+                    session.ExecuteAsync(new SimpleStatement("SELECT * FROM system.local WHERE key='local'"));
                 }
             };
             var waitHandle = new AutoResetEvent(false);

--- a/src/Cassandra.IntegrationTests/Core/PrepareSimulatorTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PrepareSimulatorTests.cs
@@ -121,7 +121,7 @@ namespace Cassandra.IntegrationTests.Core
                 var ps = session.Prepare(Query);
                 Assert.NotNull(ps);
                 Assert.AreSame(ps, session.Prepare(Query));
-                Assert.AreNotSame(ps, session.Prepare("SELECT * FROM system.local"));
+                Assert.AreNotSame(ps, session.Prepare("SELECT * FROM system.local WHERE key='local'"));
             }
         }
 

--- a/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs
@@ -730,7 +730,7 @@ namespace Cassandra.IntegrationTests.Core
                 var session = localCluster.Connect("system");
                 session.Execute("CREATE KEYSPACE bound_changeks_test WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3}");
                 TestUtils.WaitForSchemaAgreement(localCluster);
-                var ps = session.Prepare("SELECT * FROM system.local");
+                var ps = session.Prepare("SELECT * FROM system.local WHERE key='local'");
                 session.ChangeKeyspace("bound_changeks_test");
                 Assert.DoesNotThrow(() => TestHelper.Invoke(() => session.Execute(ps.Bind()), 10));
             }

--- a/src/Cassandra.IntegrationTests/Core/ReconnectionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ReconnectionTests.cs
@@ -82,10 +82,10 @@ namespace Cassandra.IntegrationTests.Core
                                         .Build())
             {
                 var session = (Session)cluster.Connect();
-                TestHelper.Invoke(() => session.Execute("SELECT * FROM system.local"), 10);
+                TestHelper.Invoke(() => session.Execute("SELECT * FROM system.local WHERE key='local'"), 10);
                 //Another session to have multiple pools
                 var dummySession = cluster.Connect();
-                TestHelper.Invoke(() => dummySession.Execute("SELECT * FROM system.local"), 10);
+                TestHelper.Invoke(() => dummySession.Execute("SELECT * FROM system.local WHERE key='local'"), 10);
                 var host = cluster.AllHosts().First();
                 var upCounter = 0;
                 var downCounter = 0;
@@ -105,7 +105,7 @@ namespace Cassandra.IntegrationTests.Core
                 // Make sure the node is considered down
                 TestHelper.RetryAssert(() =>
                 {
-                    Assert.Throws<NoHostAvailableException>(() => session.Execute("SELECT * FROM system.local"));
+                    Assert.Throws<NoHostAvailableException>(() => session.Execute("SELECT * FROM system.local WHERE key='local'"));
                     Assert.False(host.IsUp);
                     Assert.AreEqual(1, Volatile.Read(ref downCounter));
                     Assert.AreEqual(0, Volatile.Read(ref upCounter));
@@ -153,10 +153,10 @@ namespace Cassandra.IntegrationTests.Core
                                         .Build())
             {
                 var session = cluster.Connect();
-                TestHelper.Invoke(() => session.Execute("SELECT * FROM system.local"), 10);
+                TestHelper.Invoke(() => session.Execute("SELECT * FROM system.local WHERE key='local'"), 10);
                 //Another session to have multiple pools
                 var dummySession = cluster.Connect();
-                TestHelper.Invoke(() => dummySession.Execute("SELECT * FROM system.local"), 10);
+                TestHelper.Invoke(() => dummySession.Execute("SELECT * FROM system.local WHERE key='local'"), 10);
                 var hosts = cluster.AllHosts().ToList();
                 var host1 = hosts[0];
                 var host2 = hosts[1];
@@ -178,7 +178,7 @@ namespace Cassandra.IntegrationTests.Core
                 // Make sure the node is considered down
                 TestHelper.RetryAssert(() =>
                 {
-                    Assert.DoesNotThrow(() => TestHelper.Invoke(() => session.Execute("SELECT * FROM system.local"), 6));
+                    Assert.DoesNotThrow(() => TestHelper.Invoke(() => session.Execute("SELECT * FROM system.local WHERE key='local'"), 6));
                     Assert.False(host1.IsUp);
                     Assert.AreEqual(1, downCounter.GetOrAdd(nodes[0].ContactPoint, 0));
                     Assert.AreEqual(0, upCounter.GetOrAdd(nodes[0].ContactPoint, 0));
@@ -188,7 +188,7 @@ namespace Cassandra.IntegrationTests.Core
 
                 TestHelper.RetryAssert(() =>
                 {
-                    Assert.Throws<NoHostAvailableException>(() => TestHelper.Invoke(() => session.Execute("SELECT * FROM system.local"), 6));
+                    Assert.Throws<NoHostAvailableException>(() => TestHelper.Invoke(() => session.Execute("SELECT * FROM system.local WHERE key='local'"), 6));
                     Assert.False(host2.IsUp);
                     Assert.AreEqual(1, downCounter.GetOrAdd(nodes[0].ContactPoint, 0));
                     Assert.AreEqual(0, upCounter.GetOrAdd(nodes[0].ContactPoint, 0));
@@ -233,8 +233,8 @@ namespace Cassandra.IntegrationTests.Core
             {
                 var session1 = (IInternalSession)cluster.Connect();
                 var session2 = (IInternalSession)cluster.Connect();
-                TestHelper.Invoke(() => session1.Execute("SELECT * FROM system.local"), 10);
-                TestHelper.Invoke(() => session2.Execute("SELECT * FROM system.local"), 10);
+                TestHelper.Invoke(() => session1.Execute("SELECT * FROM system.local WHERE key='local'"), 10);
+                TestHelper.Invoke(() => session2.Execute("SELECT * FROM system.local WHERE key='local'"), 10);
                 var hosts = cluster.AllHosts().ToList();
                 var host1 = hosts[0];
                 var host2 = hosts[1];
@@ -259,7 +259,7 @@ namespace Cassandra.IntegrationTests.Core
                 //Force to be considered down
                 TestHelper.RetryAssert(() =>
                 {
-                    Assert.Throws<NoHostAvailableException>(() => session1.Execute("SELECT * FROM system.local"));
+                    Assert.Throws<NoHostAvailableException>(() => session1.Execute("SELECT * FROM system.local WHERE key='local'"));
                     Assert.AreEqual(1, downCounter.GetOrAdd(nodes[0].ContactPoint, 0));
                     Assert.AreEqual(0, upCounter.GetOrAdd(nodes[0].ContactPoint, 0));
                     Assert.AreEqual(1, downCounter.GetOrAdd(nodes[1].ContactPoint, 0));
@@ -279,8 +279,8 @@ namespace Cassandra.IntegrationTests.Core
                     Assert.AreEqual(1, downCounter.GetOrAdd(nodes[1].ContactPoint, 0));
                     Assert.AreEqual(1, upCounter.GetOrAdd(nodes[1].ContactPoint, 0));
                 }, 100, 200);
-                TestHelper.Invoke(() => session1.Execute("SELECT * FROM system.local"), 10);
-                TestHelper.Invoke(() => session2.Execute("SELECT * FROM system.local"), 10);
+                TestHelper.Invoke(() => session1.Execute("SELECT * FROM system.local WHERE key='local'"), 10);
+                TestHelper.Invoke(() => session2.Execute("SELECT * FROM system.local WHERE key='local'"), 10);
                 var pool1 = session1.GetOrCreateConnectionPool(host1, HostDistance.Local);
                 Assert.AreEqual(2, pool1.OpenConnections);
                 var pool2 = session1.GetOrCreateConnectionPool(host2, HostDistance.Local);
@@ -445,7 +445,7 @@ namespace Cassandra.IntegrationTests.Core
                 // force session to open connection to the new node
                 foreach (var i in Enumerable.Range(0, 5))
                 {
-                    session.Execute("SELECT * FROM system.local");
+                    session.Execute("SELECT * FROM system.local WHERE key='local'");
                 }
 
                 Assert.AreEqual(3, session.GetPools().Count());

--- a/src/Cassandra.IntegrationTests/Core/SchemaAgreementSimulacronTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SchemaAgreementSimulacronTests.cs
@@ -35,7 +35,7 @@ namespace Cassandra.IntegrationTests.Core
         private Cluster _cluster;
         private const int MaxSchemaAgreementWaitSeconds = 10;
 
-        private const string LocalSchemaVersionQuery = "SELECT schema_version FROM system.local";
+        private const string LocalSchemaVersionQuery = "SELECT schema_version FROM system.local WHERE key='local'";
         private const string PeersSchemaVersionQuery = "SELECT schema_version FROM system.peers";
 
         private static IPrimeRequest LocalSchemaVersionQueryPrime(Guid version) =>

--- a/src/Cassandra.IntegrationTests/Core/SessionAuthenticationTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SessionAuthenticationTests.cs
@@ -73,7 +73,7 @@ namespace Cassandra.IntegrationTests.Core
                     {
                         using (var session = cluster.Connect())
                         {
-                            var rowSet = session.Execute("SELECT * FROM system.local");
+                            var rowSet = session.Execute("SELECT * FROM system.local WHERE key='local'");
                             if (rowSet.Count() > 0)
                             {
                                 return testCluster;
@@ -121,7 +121,7 @@ namespace Cassandra.IntegrationTests.Core
                                  .Build())
             {
                 var session = cluster.Connect();
-                var rowSet = session.Execute("SELECT * FROM system.local");
+                var rowSet = session.Execute("SELECT * FROM system.local WHERE key='local'");
                 Assert.Greater(rowSet.Count(), 0);
             }
         }
@@ -139,7 +139,7 @@ namespace Cassandra.IntegrationTests.Core
                 var session = cluster.Connect();
                 Assert.True(testAuthProvider.NameBeforeNewAuthenticator);
                 Assert.AreEqual("org.apache.cassandra.auth.PasswordAuthenticator", testAuthProvider.Name);
-                var rowSet = session.Execute("SELECT * FROM system.local");
+                var rowSet = session.Execute("SELECT * FROM system.local WHERE key='local'");
                 Assert.Greater(rowSet.Count(), 0);
             }
         }
@@ -153,7 +153,7 @@ namespace Cassandra.IntegrationTests.Core
             using (var cluster = builder.Build())
             {
                 var session = cluster.Connect();
-                var rs = session.Execute("SELECT * FROM system.local");
+                var rs = session.Execute("SELECT * FROM system.local WHERE key='local'");
                 Assert.Greater(rs.Count(), 0);
             }
         }

--- a/src/Cassandra.IntegrationTests/Core/SessionExecuteAsyncTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SessionExecuteAsyncTests.cs
@@ -26,7 +26,7 @@ namespace Cassandra.IntegrationTests.Core
         [Test]
         public void SessionExecuteAsyncCQLQueryToSync()
         {
-            var task = Session.ExecuteAsync(new SimpleStatement("SELECT * FROM system.local"));
+            var task = Session.ExecuteAsync(new SimpleStatement("SELECT * FROM system.local WHERE key='local'"));
             //forcing it to execute sync for testing purposes
             var rowset = task.Result;
             Assert.True(rowset.Any(), "Returned result should contain rows.");
@@ -84,9 +84,9 @@ namespace Cassandra.IntegrationTests.Core
         [Test]
         public void SessionExecuteAsyncCQLQueriesParallel()
         {
-            var task1 = Session.ExecuteAsync(new SimpleStatement("select * FROM system.local"));
-            var task2 = Session.ExecuteAsync(new SimpleStatement("select key from system.local"));
-            var task3 = Session.ExecuteAsync(new SimpleStatement("select tokens from system.local"));
+            var task1 = Session.ExecuteAsync(new SimpleStatement("SELECT * FROM system.local WHERE key='local'"));
+            var task2 = Session.ExecuteAsync(new SimpleStatement("SELECT key FROM system.local WHERE key='local'"));
+            var task3 = Session.ExecuteAsync(new SimpleStatement("SELECT tokens FROM system.local WHERE key='local'"));
             //forcing the calling thread to wait for all the parallel task to finish
             Task.WaitAll(task1, task2, task3);
             Assert.NotNull(task1.Result.First().GetValue<string>("key"));

--- a/src/Cassandra.IntegrationTests/Core/SessionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SessionTests.cs
@@ -82,7 +82,7 @@ namespace Cassandra.IntegrationTests.Core
             Assert.DoesNotThrow(() =>
             {
                 var localSession = localCluster.Connect("");
-                localSession.Execute("SELECT * FROM system.local");
+                localSession.Execute("SELECT * FROM system.local WHERE key='local'");
             });
         }
 
@@ -189,7 +189,7 @@ namespace Cassandra.IntegrationTests.Core
             //Execute multiple times a query on the newly created keyspace
             for (var i = 0; i < 12; i++)
             {
-                localSession1.Execute("SELECT * FROM system.local");
+                localSession1.Execute("SELECT * FROM system.local WHERE key='local'");
             }
 
             Thread.Sleep(2000);
@@ -215,7 +215,7 @@ namespace Cassandra.IntegrationTests.Core
                 //Execute multiple times a query on the newly created keyspace
                 for (var i = 0; i < 6; i++)
                 {
-                    localSession2.Execute("SELECT * FROM system.local");
+                    localSession2.Execute("SELECT * FROM system.local WHERE key='local'");
                 }
 
                 Thread.Sleep(2000);
@@ -252,7 +252,7 @@ namespace Cassandra.IntegrationTests.Core
                 var remoteHost = localCluster.AllHosts().First(h => TestHelper.GetLastAddressByte(h) == 2);
                 var stopWatch = new Stopwatch();
                 var distanceReset = 0;
-                TestHelper.Invoke(() => localSession.Execute("SELECT key FROM system.local"), 10);
+                TestHelper.Invoke(() => localSession.Execute("SELECT key FROM system.local WHERE key='local'"), 10);
                 var hosts = localCluster.AllHosts().ToArray();
                 var pool1 = localSession.GetOrCreateConnectionPool(hosts[0], HostDistance.Local);
                 var pool2 = localSession.GetOrCreateConnectionPool(hosts[1], HostDistance.Local);
@@ -288,7 +288,7 @@ namespace Cassandra.IntegrationTests.Core
                         // The pool is looking good, there is no point in continue executing queries
                         return completedTask;
                     }
-                    return localSession.ExecuteAsync(new SimpleStatement("SELECT key FROM system.local"));
+                    return localSession.ExecuteAsync(new SimpleStatement("SELECT key FROM system.local WHERE key='local'"));
                 };
                 await TestHelper.TimesLimit(execute, 200000, 32).ConfigureAwait(false);
                 TestHelper.RetryAssert(
@@ -351,7 +351,7 @@ namespace Cassandra.IntegrationTests.Core
             {
                 host.Down += _ => Interlocked.Increment(ref isDown);
             }
-            const string query = "SELECT * from system.local";
+            const string query = "SELECT * FROM system.local WHERE key='local'";
             await TestHelper.TimesLimit(() => session1.ExecuteAsync(new SimpleStatement(query)), 100, 32).ConfigureAwait(false);
             await TestHelper.TimesLimit(() => session2.ExecuteAsync(new SimpleStatement(query)), 100, 32).ConfigureAwait(false);
             // Dispose the first session
@@ -376,7 +376,7 @@ namespace Cassandra.IntegrationTests.Core
                 using (var localCluster = ClusterBuilder().AddContactPoint(TestCluster.InitialContactPoint).Build())
                 {
                     var localSession = localCluster.Connect();
-                    var ps = localSession.Prepare("SELECT * FROM system.local");
+                    var ps = localSession.Prepare("SELECT * FROM system.local WHERE key='local'");
                     TestHelper.Invoke(() => localSession.Execute(ps.Bind()), 10);
                 }
             });
@@ -506,7 +506,7 @@ namespace Cassandra.IntegrationTests.Core
             {
                 ISession session = await cluster.ConnectAsync().ConfigureAwait(false);
                 Assert.DoesNotThrowAsync(async () =>
-                    await session.ExecuteAsync(new SimpleStatement("SELECT * FROM system.local"))
+                    await session.ExecuteAsync(new SimpleStatement("SELECT * FROM system.local WHERE key='local'"))
                                  .ConfigureAwait(false));
                 await cluster.ShutdownAsync().ConfigureAwait(false);
             }

--- a/src/Cassandra.IntegrationTests/Core/SpeculativeExecutionLongTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SpeculativeExecutionLongTests.cs
@@ -32,7 +32,7 @@ namespace Cassandra.IntegrationTests.Core
     [TestFixture, Category(TestCategory.Long), Ignore("tests that are not marked with 'short' need to be refactored/deleted")]
     public class SpeculativeExecutionLongTests : TestGlobals
     {
-        private const string QueryLocal = "SELECT key FROM system.local";
+        private const string QueryLocal = "SELECT key FROM system.local WHERE key='local'";
         private readonly List<ICluster> _clusters = new List<ICluster>();
         private IPAddress _addressNode1;
         private ITestCluster _testCluster;

--- a/src/Cassandra.IntegrationTests/Core/SpeculativeExecutionShortTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SpeculativeExecutionShortTests.cs
@@ -36,7 +36,7 @@ namespace Cassandra.IntegrationTests.Core
     [TestTimeout(60000)]
     public class SpeculativeExecutionShortTests : SimulacronTest
     {
-        private const string QueryLocal = "SELECT key FROM system.local";
+        private const string QueryLocal = "SELECT key FROM system.local WHERE key='local'";
         private readonly List<ICluster> _clusters = new List<ICluster>();
         private IPAddress _addressNode2;
 

--- a/src/Cassandra.IntegrationTests/Core/StressTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/StressTests.cs
@@ -162,7 +162,7 @@ namespace Cassandra.IntegrationTests.Core
                 for (var i = 0; i < 200; i++)
                 {
                     var session = cluster.Connect();
-                    TestHelper.ParallelInvoke(() => session.Execute("select * from system.local"), 20);
+                    TestHelper.ParallelInvoke(() => session.Execute("SELECT * FROM system.local WHERE key='local'"), 20);
                 }
                 Trace.TraceInformation("--Before disposing: {0}", GC.GetTotalMemory(false) / 1024);
                 cluster.Dispose();

--- a/src/Cassandra.IntegrationTests/Core/TimestampTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/TimestampTests.cs
@@ -41,7 +41,7 @@ namespace Cassandra.IntegrationTests.Core
                                         .Build())
             {
                 var session = cluster.Connect();
-                TestHelper.ParallelInvoke(() => session.Execute("SELECT * FROM system.local"), 10);
+                TestHelper.ParallelInvoke(() => session.Execute("SELECT * FROM system.local WHERE key='local'"), 10);
                 // The driver should use the generator against C* 2.1+
                 Assert.AreEqual(GetProtocolVersion() < ProtocolVersion.V3 ? 0 : 10, generator.GetCounter());
             }
@@ -57,7 +57,7 @@ namespace Cassandra.IntegrationTests.Core
                                         .Build())
             {
                 var session = cluster.Connect();
-                var stmt = new SimpleStatement("SELECT * FROM system.local");
+                var stmt = new SimpleStatement("SELECT * FROM system.local WHERE key='local'");
                 stmt.SetTimestamp(DateTimeOffset.Now);
                 if (GetProtocolVersion() < ProtocolVersion.V3)
                 {

--- a/src/Cassandra.IntegrationTests/DataStax/Cloud/CloudIntegrationTests.cs
+++ b/src/Cassandra.IntegrationTests/DataStax/Cloud/CloudIntegrationTests.cs
@@ -120,7 +120,7 @@ namespace Cassandra.IntegrationTests.DataStax.Cloud
 
                                 try
                                 {
-                                    await session.ExecuteAsync(new SimpleStatement("SELECT key FROM system.local")).ConfigureAwait(false);
+                                    await session.ExecuteAsync(new SimpleStatement("SELECT key FROM system.local WHERE key='local'")).ConfigureAwait(false);
                                 }
                                 catch (QueryTimeoutException) { }
                             }
@@ -169,7 +169,7 @@ namespace Cassandra.IntegrationTests.DataStax.Cloud
             var queriedHosts = new HashSet<IPAddress>();
             foreach (var i in Enumerable.Range(0, 3))
             {
-                var rs = await session.ExecuteAsync(new SimpleStatement("SELECT * FROM system.local")).ConfigureAwait(false);
+                var rs = await session.ExecuteAsync(new SimpleStatement("SELECT * FROM system.local WHERE key='local'")).ConfigureAwait(false);
                 var row = rs.First();
                 var host = session.Cluster.GetHost(new IPEndPoint(rs.Info.QueriedHost.Address, rs.Info.QueriedHost.Port));
                 Assert.IsNotNull(host);

--- a/src/Cassandra.IntegrationTests/FoundBugs/FoundBugTests.cs
+++ b/src/Cassandra.IntegrationTests/FoundBugs/FoundBugTests.cs
@@ -65,7 +65,7 @@ namespace Cassandra.IntegrationTests.FoundBugs
             string keyspaceName = "excelsior";
             session.CreateKeyspaceIfNotExists(keyspaceName);
             session.ChangeKeyspace(keyspaceName);
-            const string cqlQuery = "SELECT * from system.local";
+            const string cqlQuery = "SELECT * FROM system.local WHERE key='local'";
             var query = new SimpleStatement(cqlQuery).EnableTracing();
             {
                 var result = session.Execute(query);

--- a/src/Cassandra.IntegrationTests/Metrics/MetricsTests.cs
+++ b/src/Cassandra.IntegrationTests/Metrics/MetricsTests.cs
@@ -152,7 +152,7 @@ namespace Cassandra.IntegrationTests.Metrics
             // when new host is chosen by LBP, connection pool is created
             foreach (var _ in Enumerable.Range(0, 5))
             {
-                session.Execute("SELECT * FROM system.local");
+                session.Execute("SELECT * FROM system.local WHERE key='local'");
             }
 
             TestHelper.RetryAssert(() => { Assert.AreEqual(3, metrics.NodeMetrics.Count, "Node metrics count after bootstrap failed"); }, 10,
@@ -187,7 +187,7 @@ namespace Cassandra.IntegrationTests.Metrics
 
             foreach (var i in Enumerable.Range(0, 1000))
             {
-                session.Execute("SELECT * FROM system.local");
+                session.Execute("SELECT * FROM system.local WHERE key='local'");
             }
 
             var waitedForRefresh = false;
@@ -244,7 +244,7 @@ namespace Cassandra.IntegrationTests.Metrics
 
             foreach (var i in Enumerable.Range(0, 1000))
             {
-                session.Execute("SELECT * FROM system.local");
+                session.Execute("SELECT * FROM system.local WHERE key='local'");
             }
 
             var metrics = session.GetMetrics();
@@ -289,7 +289,7 @@ namespace Cassandra.IntegrationTests.Metrics
 
                 foreach (var i in Enumerable.Range(0, 1000))
                 {
-                    session.Execute("SELECT * FROM system.local");
+                    session.Execute("SELECT * FROM system.local WHERE key='local'");
                 }
 
                 var metrics = session.GetMetrics();

--- a/src/Cassandra.IntegrationTests/TestBase/TestUtils.cs
+++ b/src/Cassandra.IntegrationTests/TestBase/TestUtils.cs
@@ -145,7 +145,7 @@ namespace Cassandra.IntegrationTests.TestBase
             DateTime timeInTheFuture = DateTime.Now.AddSeconds(120);
             while (testCluster.Cluster.Metadata.AllHosts().ToList().Count() < expectedTotalNodeCount && DateTime.Now < timeInTheFuture)
             {
-                var rs = testCluster.Session.Execute("SELECT key FROM system.local");
+                var rs = testCluster.Session.Execute("SELECT key FROM system.local WHERE key='local'");
                 hostsQueried.Add(rs.Info.QueriedHost.Address.ToString());
                 Thread.Sleep(500);
             }
@@ -153,7 +153,7 @@ namespace Cassandra.IntegrationTests.TestBase
             timeInTheFuture = DateTime.Now.AddSeconds(120);
             while (!hostsQueried.Contains(newlyBootstrappedHost) && DateTime.Now < timeInTheFuture)
             {
-                var rs = testCluster.Session.Execute("SELECT key FROM system.local");
+                var rs = testCluster.Session.Execute("SELECT key FROM system.local WHERE key='local'");
                 hostsQueried.Add(rs.Info.QueriedHost.Address.ToString());
                 Thread.Sleep(500);
             }
@@ -637,7 +637,7 @@ namespace Cassandra.IntegrationTests.TestBase
                 //peers
                 schemaVersions.AddRange(cc.Query("SELECT peer, schema_version FROM system.peers").Select(r => r.GetValue<Guid>("schema_version")));
                 //local
-                schemaVersions.Add(cc.Query("SELECT schema_version FROM system.local").Select(r => r.GetValue<Guid>("schema_version")).First());
+                schemaVersions.Add(cc.Query("SELECT schema_version FROM system.local WHERE key='local'").Select(r => r.GetValue<Guid>("schema_version")).First());
 
                 var differentSchemas = schemaVersions.Distinct().Count();
                 if (differentSchemas <= 1 + nodesDown)

--- a/src/Cassandra/Connections/Connection.cs
+++ b/src/Cassandra/Connections/Connection.cs
@@ -105,7 +105,7 @@ namespace Cassandra.Connections
         /// </summary>
         public event Action<IConnection> Closing;
 
-        private const string IdleQuery = "SELECT key from system.local";
+        private const string IdleQuery = "SELECT key FROM system.local WHERE key='local'";
         private const long CoalescingThreshold = 8000;
 
         public ISerializer Serializer => Volatile.Read(ref _serializer);

--- a/src/Cassandra/Metadata.cs
+++ b/src/Cassandra/Metadata.cs
@@ -37,7 +37,7 @@ namespace Cassandra
     public class Metadata : IDisposable
     {
         private const string SelectSchemaVersionPeers = "SELECT schema_version FROM system.peers";
-        private const string SelectSchemaVersionLocal = "SELECT schema_version FROM system.local";
+        private const string SelectSchemaVersionLocal = "SELECT schema_version FROM system.local WHERE key='local'";
         private static readonly Logger Logger = new Logger(typeof(ControlConnection));
         private volatile TokenMap _tokenMap;
         private volatile ConcurrentDictionary<string, KeyspaceMetadata> _keyspaces = new ConcurrentDictionary<string, KeyspaceMetadata>();


### PR DESCRIPTION
Fixes: #63 