### PR TITLE
Update ssh.net to 2025.0.0

### DIFF
--- a/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
+++ b/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
@@ -56,7 +56,7 @@
   <ItemGroup>
     <PackageReference Include="App.Metrics" Version="3.2.0" />
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.5.1" />
-    <PackageReference Include="SSH.NET" Version="2020.0.2" />
+    <PackageReference Include="SSH.NET" Version="2025.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
     <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.0" />

--- a/src/Cassandra.IntegrationTests/TestBase/TestUtils.cs
+++ b/src/Cassandra.IntegrationTests/TestBase/TestUtils.cs
@@ -665,7 +665,7 @@ namespace Cassandra.IntegrationTests.TestBase
     /// </summary>
     public class ProcessOutput
     {
-        public int ExitCode { get; set; }
+        public int? ExitCode { get; set; }
 
         public StringBuilder OutputText { get; set; }
 

--- a/src/Cassandra.IntegrationTests/TestClusterManagement/RemoteCcmProcessExecuter.cs
+++ b/src/Cassandra.IntegrationTests/TestClusterManagement/RemoteCcmProcessExecuter.cs
@@ -79,6 +79,7 @@ namespace Cassandra.IntegrationTests.TestClusterManagement
                 _sshClient.Connect();
 
             var result = _sshClient.RunCommand(string.Format(@"{0} {1}", executable, args));
+
             output.ExitCode = result.ExitStatus;
             if (result.Error != null)
             {

--- a/src/Cassandra.Tests/TestTimeoutAttribute.cs
+++ b/src/Cassandra.Tests/TestTimeoutAttribute.cs
@@ -21,7 +21,7 @@ namespace Cassandra.Tests
 {
     [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Method, Inherited = false)]
     public class TestTimeoutAttribute :
-        Attribute 
+        Attribute
     {
         /// <summary>
         /// Construct a TimeoutAttribute given a time in milliseconds


### PR DESCRIPTION
New version has `int?` in `SshCommand.ExitStatus` instead of `int`. 
Small code changes needed to address that.