### PR TITLE
Update OpenTelemetry packages to 1.12.0

### DIFF
--- a/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
+++ b/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
@@ -55,7 +55,7 @@
 
   <ItemGroup>
     <PackageReference Include="App.Metrics" Version="3.2.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.5.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.12.0" />
     <PackageReference Include="SSH.NET" Version="2025.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />

--- a/src/Extensions/Cassandra.OpenTelemetry/Cassandra.OpenTelemetry.csproj
+++ b/src/Extensions/Cassandra.OpenTelemetry/Cassandra.OpenTelemetry.csproj
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.9" />
-    <PackageReference Include="OpenTelemetry.Api" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.12.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Extensions/Cassandra.OpenTelemetry/OpenTelemetryRequestTracker.cs
+++ b/src/Extensions/Cassandra.OpenTelemetry/OpenTelemetryRequestTracker.cs
@@ -134,7 +134,7 @@ namespace Cassandra.OpenTelemetry
             }
 
             activity.SetStatus(ActivityStatusCode.Error, ex.Message);
-            activity.RecordException(ex);
+            activity.AddException(ex);
 
             activity.Dispose();
 
@@ -183,7 +183,7 @@ namespace Cassandra.OpenTelemetry
             }
 
             activity.SetStatus(ActivityStatusCode.Error, ex.Message);
-            activity.RecordException(ex);
+            activity.AddException(ex);
 
             activity.Dispose();
 


### PR DESCRIPTION
`Activity.RecordException` was depricated in favor of `Activity.AddException`. It require small code changes.