### PR TITLE
cicd: replace old style oss release by prior minor enterprise

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        scylla-version: [ENTERPRISE-RELEASE, OSS-RELEASE]
+        scylla-version: [LATEST, PRIOR]
       fail-fast: false
 
     steps:
@@ -46,10 +46,10 @@ jobs:
         id: scylla-version
         run: |
           cd get-version
-          if [[ "${{ matrix.scylla-version }}" == "ENTERPRISE-RELEASE" ]]; then
-            echo "SCYLLA_VERSION=release:$(./get-version --source dockerhub-imagetag --repo scylladb/scylla-enterprise -filters "^[0-9]{4}$.^[0-9]+$.^[0-9]+$ and LAST.LAST.LAST" | tr -d '\"')" >> $GITHUB_ENV
-          elif [[ "${{ matrix.scylla-version }}" == "OSS-RELEASE" ]]; then
-            echo "SCYLLA_VERSION=release:$(./get-version --source dockerhub-imagetag --repo scylladb/scylla -filters "^[0-9]$.^[0-9]+$.^[0-9]+$ and LAST.LAST.LAST" | tr -d '\"')" >> $GITHUB_ENV
+          if [[ "${{ matrix.scylla-version }}" == "LATEST" ]]; then
+            echo "SCYLLA_VERSION=release:$(./get-version --source dockerhub-imagetag --repo scylladb/scylla -filters "^[0-9]{4}$.^[0-9]+$.^[0-9]+$ and LAST.LAST.LAST" | tr -d '\"')" >> $GITHUB_ENV
+          elif [[ "${{ matrix.scylla-version }}" == "PRIOR" ]]; then
+            echo "SCYLLA_VERSION=release:$(./get-version --source dockerhub-imagetag --repo scylladb/scylla -filters "^[0-9]{4}$.^[0-9]+$.^[0-9]+$ and LAST.LAST-1.LAST" | tr -d '\"')" >> $GITHUB_ENV
           elif echo "${{ matrix.scylla-version }}" | grep -P '^[0-9\.]+'; then # If you want to run specific version do just that
             echo "SCYLLA_VERSION=release:${{ matrix.scylla-version }}" >> $GITHUB_ENV
           else


### PR DESCRIPTION
Since 2025 scylla does not have oss and enterprise releases. There is one release, which is opensource with all enterprise features and enterprise-like versioning.