### PR TITLE
codewide: move to use `Stream.ReadExactly`

### DIFF
--- a/src/Cassandra/FrameReader.cs
+++ b/src/Cassandra/FrameReader.cs
@@ -48,7 +48,7 @@ namespace Cassandra
 
         public byte ReadByte()
         {
-            _stream.Read(_buffer, 0, 1);
+            _stream.ReadExactly(_buffer, 0, 1);
             return _buffer[0];
         }
 
@@ -57,7 +57,7 @@ namespace Cassandra
         /// </summary>
         public ushort ReadUInt16()
         {
-            _stream.Read(_buffer, 0, 2);
+            _stream.ReadExactly(_buffer, 0, 2);
             return BeConverter.ToUInt16(_buffer);
         }
 
@@ -66,13 +66,13 @@ namespace Cassandra
         /// </summary>
         public short ReadInt16()
         {
-            _stream.Read(_buffer, 0, 2);
+            _stream.ReadExactly(_buffer, 0, 2);
             return BeConverter.ToInt16(_buffer);
         }
 
         public int ReadInt32()
         {
-            _stream.Read(_buffer, 0, 4);
+            _stream.ReadExactly(_buffer, 0, 4);
             return BeConverter.ToInt32(_buffer);
         }
 
@@ -91,7 +91,7 @@ namespace Cassandra
         private string ReadStringByLength(int length)
         {
             var bytes = new byte[length];
-            _stream.Read(bytes, 0, length);
+            _stream.ReadExactly(bytes, 0, length);
             return Encoding.UTF8.GetString(bytes);
         }
 
@@ -122,14 +122,14 @@ namespace Cassandra
             IPAddress ip;
             if (length == 4)
             {
-                _stream.Read(_buffer, 0, length);
+                _stream.ReadExactly(_buffer, 0, length);
                 ip = new IPAddress(_buffer);
                 return new IPEndPoint(ip, ReadInt32());
             }
             if (length == 16)
             {
                 var buffer = new byte[16];
-                _stream.Read(buffer, 0, length);
+                _stream.ReadExactly(buffer, 0, length);
                 ip = new IPAddress(buffer);
                 return new IPEndPoint(ip, ReadInt32());
             }
@@ -184,7 +184,7 @@ namespace Cassandra
 
         public void Read(byte[] buffer, int offset, int count)
         {
-            _stream.Read(buffer, offset, count);
+            _stream.ReadExactly(buffer, offset, count);
         }
 
         /// <summary>
@@ -193,7 +193,7 @@ namespace Cassandra
         /// </summary>
         internal object ReadFromBytes(byte[] buffer, int offset, int length, ColumnTypeCode typeCode, IColumnInfo typeInfo)
         {
-            _stream.Read(buffer, offset, length);
+            _stream.ReadExactly(buffer, offset, length);
             return _serializer.Deserialize(buffer, 0, length, typeCode, typeInfo);
         }
 
@@ -203,7 +203,7 @@ namespace Cassandra
         /// </summary>
         internal object ReadFromBytesEncrypted(string ks, string table, string column, byte[] buffer, int offset, int length, ColumnTypeCode typeCode, IColumnInfo typeInfo)
         {
-            _stream.Read(buffer, offset, length);
+            _stream.ReadExactly(buffer, offset, length);
             return _serializer.DeserializeAndDecrypt(ks, table, column, buffer, 0, length, typeCode, typeInfo);
         }
     }

--- a/src/Cassandra/Utils.cs
+++ b/src/Cassandra/Utils.cs
@@ -188,7 +188,7 @@ namespace Cassandra
         {
             var buffer = new byte[stream.Length - position];
             stream.Position = position;
-            stream.Read(buffer, 0, buffer.Length - position);
+            stream.ReadExactly(buffer);
             return buffer;
         }
 
@@ -203,7 +203,7 @@ namespace Cassandra
             {
                 stream.Position = 0;
                 var itemLength = (int)stream.Length;
-                stream.Read(buffer, offset, itemLength);
+                stream.ReadExactly(buffer, offset, itemLength);
                 offset += itemLength;
             }
             return buffer;


### PR DESCRIPTION
As the new lint rule suggests ([_CA2022 - Use Stream.ReadExactly to read from streams_](https://learn.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/quality-rules/ca2022)), we should use `Stream.ReadExactly` instead of `Stream.Read` to ensure that the requested number of bytes are read from the stream. Otherwise, we might end up with incomplete reads.