### PR TITLE
docs: fix docfx multiversion

### DIFF
--- a/docs/_utils/docfx.sh
+++ b/docs/_utils/docfx.sh
@@ -7,6 +7,13 @@ if ! command -v docfx &> /dev/null; then
     exit 0
 fi
 
+# Ensure the signing key exists for docfx builds
+# The scylladb.snk file is gitignored, so use the dev key
+if [ ! -f "build/scylladb.snk" ]; then
+    echo "Using scylladb-dev.snk for documentation build..."
+    cp build/scylladb-dev.snk build/scylladb.snk
+fi
+
 # Navigate to the api-docs directory where docfx.json is located
 cd docs/source/api-docs
 


### PR DESCRIPTION
Fixes error in [docs multiversion build](https://github.com/scylladb/csharp-driver/actions/runs/20065768900/job/57553799827):

<img width="1017" height="193" alt="image" src="https://github.com/user-attachments/assets/e825f6e4-7df8-4fcb-bfd6-7a8602ce27ed" />


Which prevents the API reference to generate: https://csharp-driver.docs.scylladb.com/master/api-docs/index.html?q=cassandra