### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,8 @@
 name: Publish NuGet Package
 
+permissions:
+  contents: read
+
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/csharp-driver/security/code-scanning/4](https://github.com/scylladb/csharp-driver/security/code-scanning/4)

In general, fix this by explicitly setting a `permissions` block either at the workflow root (applies to all jobs) or within the individual job, granting only the minimal scopes required (here, read-only repository contents should suffice).

The best minimal fix without changing functionality is to add a workflow-level `permissions` block right after the `name:` line, setting `contents: read`. The current steps only need to read the repository (for `actions/checkout`) and use external secrets to publish to NuGet; they do not need to write to the repository or interact with issues/PRs. No other permissions are required based on the shown snippet. This change must be made in `.github/workflows/publish.yml`, keeping the rest of the workflow intact.

Concretely, edit `.github/workflows/publish.yml` to insert:

```yaml
permissions:
  contents: read
```

after line 1 (`name: Publish NuGet Package`). No imports or additional methods are needed since this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
