### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -13,6 +13,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/csharp-driver/security/code-scanning/2](https://github.com/scylladb/csharp-driver/security/code-scanning/2)

In general, the fix is to explicitly set a minimal `permissions` block for any job or entire workflow that does not need broad default `GITHUB_TOKEN` permissions. For this workflow, we should add a `permissions` block that grants only `contents: read` to the `build` job, since it just checks out code, sets up environments, builds docs, and uploads an artifact.

The best minimal change is to edit `.github/workflows/docs-pages.yml` and, under `jobs:  build:`, add a `permissions` section before `runs-on`. This will override any broader repository defaults for that job without affecting the already-correct `permissions` on the `release` job. No imports or additional definitions are required, as this is purely a YAML configuration change for the GitHub Actions workflow.

Concretely:
- In `.github/workflows/docs-pages.yml`, locate the `build:` job definition.
- Insert:
  ```yaml
    permissions:
      contents: read
  ```
  between `build:` and `runs-on: ubuntu-latest`.
This change leaves all existing behavior intact while ensuring the token for the `build` job is least-privileged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
