### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -14,6 +14,9 @@ on:
       - ".github/workflows/docs-pr.yml"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/csharp-driver/security/code-scanning/1](https://github.com/scylladb/csharp-driver/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions:` block in the workflow (either at the top level or per job) to restrict the `GITHUB_TOKEN` to the minimum required scopes, rather than relying on repository defaults. For this docs build job, it only needs to read repository contents (for `actions/checkout` and building docs from source), so `contents: read` is sufficient.

The single best fix with no behavior change is to add a top-level `permissions:` block applying to all jobs in this workflow. This ensures the `build` job runs with a read-only token for repository contents. Concretely, in `.github/workflows/docs-pr.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` section (ending at line 15–16) and the `jobs:` key (line 17). No other changes, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
