### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/csharp-driver/security/code-scanning/3](https://github.com/scylladb/csharp-driver/security/code-scanning/3)

To fix the problem, explicitly declare restricted GITHUB_TOKEN permissions in the workflow. Since both jobs only need to read the repository contents (for `actions/checkout` and running tests on the code), we can set `contents: read` either at the workflow level (applies to all jobs without their own `permissions`) or separately for each job. The cleanest solution with no functional change is to add a single top-level `permissions:` block with `contents: read`.

Concretely, edit `.github/workflows/main.yml` near the top, right after the `name: CI` line (before the `on:` block), to add:

```yaml
permissions:
  contents: read
```

This ensures the GITHUB_TOKEN is restricted to read-only access to repository contents for all jobs in this workflow. No other imports, methods, or definitions are needed since this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
