### PR TITLE
Remove any suffix after hyphen from scylla version

### DIFF
--- a/src/Cassandra.IntegrationTests/TestClusterManagement/TestClusterManager.cs
+++ b/src/Cassandra.IntegrationTests/TestClusterManagement/TestClusterManager.cs
@@ -105,7 +105,7 @@ namespace Cassandra.IntegrationTests.TestClusterManagement
                         ScyllaVersionString);
                     testCluster.Create(1, null);
                     string versionString = testCluster.GetVersion(1);
-                    _scyllaVersion = new Version(versionString);
+                    _scyllaVersion = Version.Parse(versionString.Split('-', '~')[0]);
                     return _scyllaVersion;
                 }
                 finally


### PR DESCRIPTION
This is needed so the tests work properly on driver matrix where versions can have `-dev` suffix.