### PR TITLE
Use global.json for SDK version in CI workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
-          dotnet-version: '9.0.x'
+          global-json-file: global.json
 
       - name: Run dotnet format (checks formatting)
         run: make check
@@ -83,6 +83,7 @@ jobs:
       - name: Setup .NET ${{ matrix.dotnet-version }}
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
+          global-json-file: global.json
           dotnet-version: ${{ matrix.dotnet-version }}
 
       - name: Set up JDK 8
@@ -134,4 +135,3 @@ jobs:
       - name: Run integration tests on Scylla
         if: env.SKIP_TEST != 'true'
         run: make test-integration-scylla
-

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,11 +37,27 @@ jobs:
     - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       with:
         ref: ${{ inputs.target_tag || github.ref }}
+        persist-credentials: false
+
+    - name: Checkout SDK configuration
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      with:
+        ref: ${{ github.event.repository.default_branch }}
+        sparse-checkout: global.json
+        sparse-checkout-cone-mode: false
+        path: .sdk-config
+        persist-credentials: false
+
+    - name: Add SDK configuration to legacy checkout
+      run: |
+        if [[ ! -f global.json ]]; then
+          cp .sdk-config/global.json global.json
+        fi
 
     - name: Setup .NET
       uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
       with:
-        dotnet-version: '9.0.x'
+        global-json-file: global.json
 
     - name: Publish to NuGet (Dry Run)
       if: ${{ inputs.dry-run == true }}

--- a/.gitignore
+++ b/.gitignore
@@ -58,18 +58,12 @@ docs/source/api-docs/datastax-template
 # Ignore active snk file
 build/scylladb.snk
 
-# Ignore local dotnet config
-global.json
-
 # Ignore python virtual environments
 docs/.venv
 .venv*/
 
 # Ignore release leftovers
 nupkgs/
-
-# Ignore dotnet project configuration
-global.json
 
 # Personal and AI TODO list
 TODO*.md

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ fix:
 .PHONY: test-unit
 test-unit: .use-development-snk
 	dotnet build-server shutdown
-	dotnet test $(TEST_TARGET_OPTIONS) src/Cassandra.Tests/Cassandra.Tests.csproj
+	dotnet test --maxcpucount:1 $(TEST_TARGET_OPTIONS) src/Cassandra.Tests/Cassandra.Tests.csproj
 
 TEST_INTEGRATION_SCYLLA_FILTER ?= (FullyQualifiedName!~ClientWarningsTests & FullyQualifiedName!~CustomPayloadTests & FullyQualifiedName!~Connect_With_Ssl_Test & FullyQualifiedName!~Should_UpdateHosts_When_HostIpChanges & FullyQualifiedName!~Should_UseNewHostInQueryPlans_When_HostIsDecommissionedAndJoinsAgain & FullyQualifiedName!~Should_RemoveNodeMetricsAndDisposeMetricsContext_When_HostIsRemoved & FullyQualifiedName!~Virtual_Keyspaces_Are_Included & FullyQualifiedName!~Virtual_Table_Metadata_Test & FullyQualifiedName!~SessionAuthenticationTests & FullyQualifiedName!~Custom_MetadataTest & FullyQualifiedName!~Should_Use_Custom_TypeSerializers & FullyQualifiedName!~LinqWhere_WithVectors & FullyQualifiedName!~SimpleStatement_With_No_Compact_Enabled_Should_Reveal_Non_Schema_Columns & FullyQualifiedName!~SimpleStatement_With_No_Compact_Disabled_Should_Not_Reveal_Non_Schema_Columns & FullyQualifiedName!~ColumnClusteringOrderReversedTest & FullyQualifiedName!~GetMaterializedView_Should_Refresh_View_Metadata_Via_Events & FullyQualifiedName!~MaterializedView_Base_Table_Column_Addition & FullyQualifiedName!~MultipleSecondaryIndexTest & FullyQualifiedName!~RaiseErrorOnInvalidMultipleSecondaryIndexTest & FullyQualifiedName!~TableMetadataAllTypesTest & FullyQualifiedName!~TableMetadataClusteringOrderTest & FullyQualifiedName!~TableMetadataCollectionsSecondaryIndexTest & FullyQualifiedName!~TableMetadataCompositePartitionKeyTest & FullyQualifiedName!~TupleMetadataTest & FullyQualifiedName!~Udt_Case_Sensitive_Metadata_Test & FullyQualifiedName!~UdtMetadataTest & FullyQualifiedName!~Should_Retrieve_Table_Metadata & FullyQualifiedName!~CreateTable_With_Frozen_Key & FullyQualifiedName!~CreateTable_With_Frozen_Udt & FullyQualifiedName!~CreateTable_With_Frozen_Value & FullyQualifiedName!~Should_AllMetricsHaveValidValues_When_AllNodesAreUp & FullyQualifiedName!~SimpleStatement_Dictionary_Parameters_CaseInsensitivity_ExcessOfParams & FullyQualifiedName!~SimpleStatement_Dictionary_Parameters_CaseInsensitivity_NoOverload & FullyQualifiedName!~TokenAware_TransientReplication_NoHopsAndOnlyFullReplicas & FullyQualifiedName!~GetFunction_Should_Return_Most_Up_To_Date_Metadata_Via_Events & FullyQualifiedName!~LargeDataTests & FullyQualifiedName!~MetadataTests & FullyQualifiedName!~MultiThreadingTests & FullyQualifiedName!~PoolTests & FullyQualifiedName!~PrepareLongTests & FullyQualifiedName!~SpeculativeExecutionLongTests & FullyQualifiedName!~StressTests & FullyQualifiedName!~TransitionalAuthenticationTests & FullyQualifiedName!~ProxyAuthenticationTests & FullyQualifiedName!~CloudIntegrationTests & FullyQualifiedName!~CoreGraphTests & FullyQualifiedName!~GraphTests & FullyQualifiedName!~InsightsIntegrationTests & FullyQualifiedName!~DateRangeTests & FullyQualifiedName!~FoundBugTests & FullyQualifiedName!~GeometryTests & FullyQualifiedName!~LoadBalancingPolicyTests & FullyQualifiedName!~ConsistencyTests & FullyQualifiedName!~LoadBalancingPolicyTests & FullyQualifiedName!~ReconnectionPolicyTests & FullyQualifiedName!~RetryPolicyTests)
 TEST_INTEGRATION_OPTIONS ?= -l "console;verbosity=detailed"
@@ -63,11 +63,11 @@ TEST_INTEGRATION_CSPROJ ?= src/Cassandra.IntegrationTests/Cassandra.IntegrationT
 .PHONY: test-integration-scylla
 test-integration-scylla: .use-development-snk .prepare-scylla-ccm
 	dotnet build-server shutdown
-	CCM_DISTRIBUTION=scylla dotnet test $(TEST_TARGET_OPTIONS) $(TEST_INTEGRATION_CSPROJ) $(TEST_INTEGRATION_OPTIONS) --filter "$(TEST_INTEGRATION_SCYLLA_FILTER)"
+	CCM_DISTRIBUTION=scylla dotnet test --maxcpucount:1 $(TEST_TARGET_OPTIONS) $(TEST_INTEGRATION_CSPROJ) $(TEST_INTEGRATION_OPTIONS) --filter "$(TEST_INTEGRATION_SCYLLA_FILTER)"
 
 .PHONY: test-integration-cassandra
 test-integration-cassandra: .use-development-snk .prepare-cassandra-ccm
-	CCM_DISTRIBUTION=cassandra dotnet test $(TEST_TARGET_OPTIONS) $(TEST_INTEGRATION_CSPROJ) $(TEST_INTEGRATION_OPTIONS)
+	CCM_DISTRIBUTION=cassandra dotnet test --maxcpucount:1 $(TEST_TARGET_OPTIONS) $(TEST_INTEGRATION_CSPROJ) $(TEST_INTEGRATION_OPTIONS)
 
 .prepare-cassandra-ccm:
 	@ccm --help 2>/dev/null 1>&2; if [[ $$? -lt 127 ]] && grep CASSANDRA ${CCM_CONFIG_DIR}/ccm-type 2>/dev/null 1>&2 && grep ${CCM_CASSANDRA_VERSION} ${CCM_CONFIG_DIR}/ccm-version 2>/dev//null  1>&2; then \

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "9.0.305",
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
+  }
+}


### PR DESCRIPTION
## Summary
- Rebased onto current `master`.
- Track `global.json` with .NET SDK 9.0.305 and `latestFeature` roll-forward.
- Configure CI and NuGet publish workflows to install the SDK declared by `global.json`.
- Keep matrix `dotnet-version` inputs so target runtimes remain installed for net6/net7/net8/net9 tests.
- Supply current SDK policy when manually publishing legacy refs that predate `global.json`.
- Disable persisted checkout credentials in the publish job.
- Serialize MSBuild nodes for test builds while preserving test-runner parallelism.
- Preserve pinned GitHub Action commit SHAs.

## Root cause
Test projects reach `Cassandra.csproj` through multiple project-reference paths. Parallel MSBuild nodes can build the same target concurrently and race while writing shared `obj`/`bin` files, producing intermittent MSB3491/MSB4018 failures. Hosted runners also selected preinstalled SDK 10 instead of intended SDK 9. Original PR failed immediately because `global.json` was ignored and absent from repository.

This revision tracks SDK policy explicitly and uses `--maxcpucount:1` for test builds. NUnit execution remains parallel. Publish targets that predate the tracked policy receive a sparse-checkout copy from the default branch before SDK setup.

## Validation
- [x] `global.json` parses and selects SDK 9.0.305 locally
- [x] CI workflow YAML parses
- [x] `make check`
- [x] `TARGET_FRAMEWORK=net9 make test-unit` (1,430 passed; 4 platform skips)
- [x] `TARGET_FRAMEWORK=net7 make test-unit` (1,430 passed; 4 platform skips)
- [x] GitHub CI matrix: net6/net7/net8/net9 integration tests
- [x] CodeQL
- [x] CodeRabbit review