### PR TITLE
Add table-aware GetReplicas API and deprecate legacy overloads

### DIFF
--- a/src/Cassandra.IntegrationTests/Core/MetadataTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/MetadataTests.cs
@@ -49,7 +49,7 @@ namespace Cassandra.IntegrationTests.Core
             Assert.Greater(initialLength, 0);
 
             //GetReplicas should yield the primary replica when the Keyspace is not found
-            Assert.AreEqual(1, cluster.GetReplicas("ks2", new byte[] { 0, 0, 0, 1 }).Count);
+            Assert.AreEqual(1, cluster.GetReplicas("ks2", null, new byte[] { 0, 0, 0, 1 }).Count);
 
             const string createKeyspaceQuery = "CREATE KEYSPACE {0} WITH replication = {{ 'class' : '{1}', {2} }}";
             session.Execute(string.Format(createKeyspaceQuery, "ks1", "NetworkTopologyStrategy", "'replication_factor' : 1"));
@@ -66,7 +66,7 @@ namespace Cassandra.IntegrationTests.Core
             Assert.NotNull(ks2);
             Assert.AreEqual(ks2.Replication["replication_factor"], 3);
             //GetReplicas should yield the 2 replicas (rf=3 but cluster=2) when the Keyspace is found
-            Assert.AreEqual(2, cluster.GetReplicas("ks2", new byte[] { 0, 0, 0, 1 }).Count);
+            Assert.AreEqual(2, cluster.GetReplicas("ks2", null, new byte[] { 0, 0, 0, 1 }).Count);
             var ks3 = cluster.Metadata.GetKeyspace("ks3");
             Assert.NotNull(ks3);
             Assert.AreEqual(ks3.Replication["dc1"], 1);

--- a/src/Cassandra.IntegrationTests/MetadataTests/TokenMapSchemaChangeMetadataSyncTests.cs
+++ b/src/Cassandra.IntegrationTests/MetadataTests/TokenMapSchemaChangeMetadataSyncTests.cs
@@ -77,7 +77,7 @@ namespace Cassandra.IntegrationTests.MetadataTests
                 newSession.ChangeKeyspace(keyspaceName);
 
                 Assert.IsNull(newCluster.Metadata.TokenToReplicasMap.GetByKeyspace(keyspaceName));
-                Assert.AreEqual(1, newCluster.Metadata.GetReplicas(keyspaceName, Encoding.UTF8.GetBytes("123")).Count);
+                Assert.AreEqual(1, newCluster.Metadata.GetReplicas(keyspaceName, null, Encoding.UTF8.GetBytes("123")).Count);
                 Assert.IsTrue(object.ReferenceEquals(newCluster.Metadata.TokenToReplicasMap, oldTokenMap));
             }
         }
@@ -102,7 +102,7 @@ namespace Cassandra.IntegrationTests.MetadataTests
                 TestUtils.WaitForSchemaAgreement(newCluster);
                 var oldTokenMap = newCluster.Metadata.TokenToReplicasMap;
                 Assert.IsNull(newCluster.Metadata.TokenToReplicasMap.GetByKeyspace(keyspaceName));
-                Assert.AreEqual(1, newCluster.Metadata.GetReplicas(keyspaceName, Encoding.UTF8.GetBytes("123")).Count);
+                Assert.AreEqual(1, newCluster.Metadata.GetReplicas(keyspaceName, null, Encoding.UTF8.GetBytes("123")).Count);
                 Assert.IsTrue(object.ReferenceEquals(newCluster.Metadata.TokenToReplicasMap, oldTokenMap));
             }
         }
@@ -126,7 +126,7 @@ namespace Cassandra.IntegrationTests.MetadataTests
                 {
                     var replicas = newCluster.Metadata.TokenToReplicasMap.GetByKeyspace(keyspaceName);
                     Assert.IsNull(replicas);
-                    Assert.AreEqual(1, newCluster.Metadata.GetReplicas(keyspaceName, Encoding.UTF8.GetBytes("123")).Count);
+                    Assert.AreEqual(1, newCluster.Metadata.GetReplicas(keyspaceName, null, Encoding.UTF8.GetBytes("123")).Count);
                 });
 
                 Assert.AreEqual(3, newCluster.Metadata.Hosts.Count(h => h.IsUp));
@@ -139,7 +139,7 @@ namespace Cassandra.IntegrationTests.MetadataTests
                 {
                     var replicas = newCluster.Metadata.TokenToReplicasMap.GetByKeyspace(keyspaceName);
                     Assert.IsNull(replicas);
-                    Assert.AreEqual(1, newCluster.Metadata.GetReplicas(keyspaceName, Encoding.UTF8.GetBytes("123")).Count);
+                    Assert.AreEqual(1, newCluster.Metadata.GetReplicas(keyspaceName, null, Encoding.UTF8.GetBytes("123")).Count);
                 });
 
                 Assert.AreEqual(3, newCluster.Metadata.Hosts.Count(h => h.IsUp));
@@ -169,9 +169,9 @@ namespace Cassandra.IntegrationTests.MetadataTests
                 var oldTokenMap = newCluster.Metadata.TokenToReplicasMap;
                 var replicas = newCluster.Metadata.TokenToReplicasMap.GetByKeyspace(keyspaceName);
                 Assert.IsNull(replicas);
-                Assert.AreEqual(1, newCluster.Metadata.GetReplicas(keyspaceName, Encoding.UTF8.GetBytes("123")).Count);
+                Assert.AreEqual(1, newCluster.Metadata.GetReplicas(keyspaceName, null, Encoding.UTF8.GetBytes("123")).Count);
                 Assert.AreEqual(3, newCluster.Metadata.Hosts.Count(h => h.IsUp));
-                Assert.AreEqual(1, newCluster.Metadata.GetReplicas(keyspaceName, Encoding.UTF8.GetBytes("123")).Count);
+                Assert.AreEqual(1, newCluster.Metadata.GetReplicas(keyspaceName, null, Encoding.UTF8.GetBytes("123")).Count);
 
                 await newCluster.RefreshSchemaAsync(keyspaceName).ConfigureAwait(false);
 
@@ -179,7 +179,7 @@ namespace Cassandra.IntegrationTests.MetadataTests
 
                 replicas = newCluster.Metadata.TokenToReplicasMap.GetByKeyspace(keyspaceName);
                 Assert.AreEqual(newCluster.Metadata.Hosts.Sum(h => h.Tokens.Count()), replicas.Count);
-                Assert.AreEqual(3, newCluster.Metadata.GetReplicas(keyspaceName, Encoding.UTF8.GetBytes("123")).Count);
+                Assert.AreEqual(3, newCluster.Metadata.GetReplicas(keyspaceName, null, Encoding.UTF8.GetBytes("123")).Count);
 
                 Assert.AreEqual(3, newCluster.Metadata.Hosts.Count(h => h.IsUp));
                 Assert.IsTrue(object.ReferenceEquals(newCluster.Metadata.TokenToReplicasMap, oldTokenMap));
@@ -207,10 +207,10 @@ namespace Cassandra.IntegrationTests.MetadataTests
                 var newSession = newCluster.Connect(keyspaceName);
                 var replicas = newCluster.Metadata.TokenToReplicasMap.GetByKeyspace(keyspaceName);
                 Assert.IsNull(replicas);
-                Assert.AreEqual(1, newCluster.Metadata.GetReplicas(keyspaceName, Encoding.UTF8.GetBytes("123")).Count);
+                Assert.AreEqual(1, newCluster.Metadata.GetReplicas(keyspaceName, null, Encoding.UTF8.GetBytes("123")).Count);
                 var oldTokenMap = newCluster.Metadata.TokenToReplicasMap;
                 Assert.AreEqual(3, newCluster.Metadata.Hosts.Count(h => h.IsUp));
-                Assert.AreEqual(1, newCluster.Metadata.GetReplicas(keyspaceName, Encoding.UTF8.GetBytes("123")).Count);
+                Assert.AreEqual(1, newCluster.Metadata.GetReplicas(keyspaceName, null, Encoding.UTF8.GetBytes("123")).Count);
 
                 await newCluster.RefreshSchemaAsync().ConfigureAwait(false);
 
@@ -218,11 +218,11 @@ namespace Cassandra.IntegrationTests.MetadataTests
 
                 replicas = newCluster.Metadata.TokenToReplicasMap.GetByKeyspace(keyspaceName);
                 Assert.AreEqual(newCluster.Metadata.Hosts.Sum(h => h.Tokens.Count()), replicas.Count);
-                Assert.AreEqual(3, newCluster.Metadata.GetReplicas(keyspaceName, Encoding.UTF8.GetBytes("123")).Count);
+                Assert.AreEqual(3, newCluster.Metadata.GetReplicas(keyspaceName, null, Encoding.UTF8.GetBytes("123")).Count);
 
                 replicas = newCluster.Metadata.TokenToReplicasMap.GetByKeyspace(keyspaceName1);
                 Assert.AreEqual(newCluster.Metadata.Hosts.Sum(h => h.Tokens.Count()), replicas.Count);
-                Assert.AreEqual(3, newCluster.Metadata.GetReplicas(keyspaceName, Encoding.UTF8.GetBytes("123")).Count);
+                Assert.AreEqual(3, newCluster.Metadata.GetReplicas(keyspaceName, null, Encoding.UTF8.GetBytes("123")).Count);
 
                 Assert.AreEqual(3, newCluster.Metadata.Hosts.Count(h => h.IsUp));
                 Assert.IsFalse(object.ReferenceEquals(newCluster.Metadata.TokenToReplicasMap, oldTokenMap));

--- a/src/Cassandra.IntegrationTests/MetadataTests/TokenMapSchemaChangeTests.cs
+++ b/src/Cassandra.IntegrationTests/MetadataTests/TokenMapSchemaChangeTests.cs
@@ -96,7 +96,7 @@ namespace Cassandra.IntegrationTests.MetadataTests
             {
                 var replicas = newCluster.Metadata.TokenToReplicasMap.GetByKeyspace(keyspaceName);
                 Assert.AreEqual(newCluster.Metadata.Hosts.Sum(h => h.Tokens.Count()), replicas.Count);
-                Assert.AreEqual(3, newCluster.Metadata.GetReplicas(keyspaceName, Encoding.UTF8.GetBytes("123")).Count);
+                Assert.AreEqual(3, newCluster.Metadata.GetReplicas(keyspaceName, null, Encoding.UTF8.GetBytes("123")).Count);
             });
 
             Assert.AreEqual(3, newCluster.Metadata.Hosts.Count(h => h.IsUp));
@@ -109,7 +109,7 @@ namespace Cassandra.IntegrationTests.MetadataTests
             {
                 var replicas = newCluster.Metadata.TokenToReplicasMap.GetByKeyspace(keyspaceName);
                 Assert.AreEqual(newCluster.Metadata.Hosts.Sum(h => h.Tokens.Count()), replicas.Count);
-                Assert.AreEqual(2, newCluster.Metadata.GetReplicas(keyspaceName, Encoding.UTF8.GetBytes("123")).Count);
+                Assert.AreEqual(2, newCluster.Metadata.GetReplicas(keyspaceName, null, Encoding.UTF8.GetBytes("123")).Count);
             });
 
             Assert.AreEqual(3, newCluster.Metadata.Hosts.Count(h => h.IsUp));

--- a/src/Cassandra.IntegrationTests/MetadataTests/TokenMapTopologyChangeTests.cs
+++ b/src/Cassandra.IntegrationTests/MetadataTests/TokenMapTopologyChangeTests.cs
@@ -78,8 +78,8 @@ namespace Cassandra.IntegrationTests.MetadataTests
                     Assert.AreEqual(3, ClusterObjSync.Metadata.Hosts.Count);
                     Assert.AreEqual(3, ClusterObjNotSync.Metadata.Hosts.Count);
 
-                    replicasSync = ClusterObjSync.Metadata.GetReplicas(keyspaceName, Encoding.UTF8.GetBytes("123"));
-                    replicasNotSync = ClusterObjNotSync.Metadata.GetReplicas(keyspaceName, Encoding.UTF8.GetBytes("123"));
+                    replicasSync = ClusterObjSync.Metadata.GetReplicas(keyspaceName, null, Encoding.UTF8.GetBytes("123"));
+                    replicasNotSync = ClusterObjNotSync.Metadata.GetReplicas(keyspaceName, null, Encoding.UTF8.GetBytes("123"));
 
                     Assert.AreEqual(3, replicasSync.Count);
                     Assert.AreEqual(1, replicasNotSync.Count);
@@ -97,8 +97,8 @@ namespace Cassandra.IntegrationTests.MetadataTests
                     Assert.AreEqual(2, ClusterObjSync.Metadata.Hosts.Count, "ClusterObjSync.Metadata.Hosts.Count");
                     Assert.AreEqual(2, ClusterObjNotSync.Metadata.Hosts.Count, "ClusterObjNotSync.Metadata.Hosts.Count");
 
-                    replicasSync = ClusterObjSync.Metadata.GetReplicas(keyspaceName, Encoding.UTF8.GetBytes("123"));
-                    replicasNotSync = ClusterObjNotSync.Metadata.GetReplicas(keyspaceName, Encoding.UTF8.GetBytes("123"));
+                    replicasSync = ClusterObjSync.Metadata.GetReplicas(keyspaceName, null, Encoding.UTF8.GetBytes("123"));
+                    replicasNotSync = ClusterObjNotSync.Metadata.GetReplicas(keyspaceName, null, Encoding.UTF8.GetBytes("123"));
 
                     Assert.AreEqual(2, replicasSync.Count, "replicasSync.Count");
                     Assert.AreEqual(1, replicasNotSync.Count, "replicasNotSync.Count");
@@ -116,8 +116,8 @@ namespace Cassandra.IntegrationTests.MetadataTests
                     Assert.AreEqual(3, ClusterObjSync.Metadata.Hosts.Count);
                     Assert.AreEqual(3, ClusterObjNotSync.Metadata.Hosts.Count);
 
-                    replicasSync = ClusterObjSync.Metadata.GetReplicas(keyspaceName, Encoding.UTF8.GetBytes("123"));
-                    replicasNotSync = ClusterObjNotSync.Metadata.GetReplicas(keyspaceName, Encoding.UTF8.GetBytes("123"));
+                    replicasSync = ClusterObjSync.Metadata.GetReplicas(keyspaceName, null, Encoding.UTF8.GetBytes("123"));
+                    replicasNotSync = ClusterObjNotSync.Metadata.GetReplicas(keyspaceName, null, Encoding.UTF8.GetBytes("123"));
 
                     Assert.AreEqual(3, replicasSync.Count);
                     Assert.AreEqual(1, replicasNotSync.Count);

--- a/src/Cassandra.IntegrationTests/Policies/Tests/LoadBalancingPolicyShortTests.cs
+++ b/src/Cassandra.IntegrationTests/Policies/Tests/LoadBalancingPolicyShortTests.cs
@@ -396,7 +396,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                 // Manually calculate the routing key
                 var routingKey = SerializerManager.Default.GetCurrentSerializer().Serialize(id);
                 // Get the replicas
-                var replicas = cluster.GetReplicas(ks, routingKey);
+                var replicas = cluster.GetReplicas(ks, "tbl1", routingKey);
                 Assert.AreEqual(metadataSync ? 2 : 1, replicas.Count);
                 CollectionAssert.AreEquivalent(replicas.Select(h => h.Host.Address), coordinators);
             }

--- a/src/Cassandra.IntegrationTests/ScyllaLwtTests.cs
+++ b/src/Cassandra.IntegrationTests/ScyllaLwtTests.cs
@@ -71,7 +71,7 @@ namespace Cassandra.IntegrationTests
         {
             var routingKey = new RoutingKey();
             routingKey.RawRoutingKey = PkBytes;
-            var replicas = _cluster.GetReplicas("lwt_test", routingKey.RawRoutingKey);
+            var replicas = _cluster.GetReplicas("lwt_test", "foo", routingKey.RawRoutingKey);
             return replicas.First().Host;
         }
 

--- a/src/Cassandra.Tests/PoliciesUnitTests.cs
+++ b/src/Cassandra.Tests/PoliciesUnitTests.cs
@@ -489,8 +489,8 @@ namespace Cassandra.Tests
                 .Returns(hostList)
                 .Verifiable();
             clusterMock
-                .Setup(c => c.GetReplicas(It.IsAny<string>(), It.IsAny<byte[]>()))
-                .Returns<string, byte[]>((keyspace, key) =>
+                .Setup(c => c.GetReplicas(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<byte[]>()))
+                .Returns<string, string, byte[]>((keyspace, table, key) =>
                 {
                     var i = key[0];
                     return hostList.Where(h =>
@@ -550,8 +550,8 @@ namespace Cassandra.Tests
                 .Returns(hostList)
                 .Verifiable();
             clusterMock
-                .Setup(c => c.GetReplicas(It.IsAny<string>(), It.IsAny<byte[]>()))
-                .Returns<string, byte[]>((keyspace, key) =>
+                .Setup(c => c.GetReplicas(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<byte[]>()))
+                .Returns<string, string, byte[]>((keyspace, table, key) =>
                 {
                     var i = key[0];
                     return hostList.Where(h =>

--- a/src/Cassandra.Tests/StatementTests.cs
+++ b/src/Cassandra.Tests/StatementTests.cs
@@ -332,7 +332,7 @@ namespace Cassandra.Tests
             var rawRoutingKey = new byte[] { 1, 2, 3, 4 };
             var lbp = new TokenAwarePolicy(new ClusterTests.FakeLoadBalancingPolicy());
             var clusterMock = Mock.Of<IInternalCluster>();
-            Mock.Get(clusterMock).Setup(c => c.GetReplicas(It.IsAny<string>(), It.IsAny<byte[]>()))
+            Mock.Get(clusterMock).Setup(c => c.GetReplicas(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<byte[]>()))
                 .Returns(new List<HostShard>());
             Mock.Get(clusterMock).Setup(c => c.AllHosts())
                 .Returns(new List<Host>());
@@ -345,7 +345,7 @@ namespace Cassandra.Tests
 
             var _ = lbp.NewQueryPlan("ks2", batch).ToList();
 
-            Mock.Get(clusterMock).Verify(c => c.GetReplicas("ks1", rawRoutingKey), Times.Once);
+            Mock.Get(clusterMock).Verify(c => c.GetReplicas("ks1", null, rawRoutingKey), Times.Once);
         }
     }
 }

--- a/src/Cassandra/Cluster.cs
+++ b/src/Cassandra/Cluster.cs
@@ -490,15 +490,23 @@ namespace Cassandra
         }
 
         /// <inheritdoc />
+        [Obsolete("Use GetReplicas(string keyspace, string table, byte[] partitionKey) for tablet-aware replica resolution.")]
         public ICollection<HostShard> GetReplicas(byte[] partitionKey)
         {
-            return Metadata.GetReplicas(partitionKey);
+            return Metadata.GetReplicas(null, null, partitionKey);
         }
 
         /// <inheritdoc />
+        [Obsolete("Use GetReplicas(string keyspace, string table, byte[] partitionKey) for tablet-aware replica resolution.")]
         public ICollection<HostShard> GetReplicas(string keyspace, byte[] partitionKey)
         {
-            return Metadata.GetReplicas(keyspace, partitionKey);
+            return Metadata.GetReplicas(keyspace, null, partitionKey);
+        }
+
+        /// <inheritdoc />
+        public ICollection<HostShard> GetReplicas(string keyspace, string table, byte[] partitionKey)
+        {
+            return Metadata.GetReplicas(keyspace, table, partitionKey);
         }
 
         private void OnHostRemoved(Host h)

--- a/src/Cassandra/ICluster.cs
+++ b/src/Cassandra/ICluster.cs
@@ -31,9 +31,9 @@ namespace Cassandra
     /// Cassandra cluster would be:
     /// </para>
     /// <code>
-    /// Cluster cluster = Cluster.Builder().AddContactPoint("192.168.0.1").Build(); 
-    /// Session session = cluster.Connect("db1"); 
-    /// foreach (var row in session.Execute("SELECT * FROM table1")) 
+    /// Cluster cluster = Cluster.Builder().AddContactPoint("192.168.0.1").Build();
+    /// Session session = cluster.Connect("db1");
+    /// foreach (var row in session.Execute("SELECT * FROM table1"))
     ///     // do something ...
     /// </code>
     /// <para>
@@ -46,7 +46,7 @@ namespace Cassandra
     public interface ICluster : IDisposable
     {
         /// <summary>
-        ///  Gets read-only metadata on the connected cluster. 
+        ///  Gets read-only metadata on the connected cluster.
         /// <para>This includes the
         ///  know nodes (with their status as seen by the driver) as well as the schema
         ///  definitions.
@@ -108,19 +108,31 @@ namespace Cassandra
         Host GetHost(IPEndPoint address);
 
         /// <summary>
-        /// Gets a collection of replicas for a given partitionKey. Backward-compatibility only, use GetReplicas(keyspace, partitionKey) instead.
+        /// Gets a collection of replicas for a given partitionKey. Backward-compatibility only.
         /// </summary>
         /// <param name="partitionKey">Byte array representing the partition key</param>
         /// <returns></returns>
+        [Obsolete("Use GetReplicas(string keyspace, string table, byte[] partitionKey) for tablet-aware replica resolution.")]
         ICollection<HostShard> GetReplicas(byte[] partitionKey);
 
         /// <summary>
         /// Gets a collection of replicas for a given partitionKey on a given keyspace
         /// </summary>
-        /// <param name="keyspace">Byte array representing the partition key</param>
+        /// <param name="keyspace">The keyspace name</param>
         /// <param name="partitionKey">Byte array representing the partition key</param>
         /// <returns></returns>
+        [Obsolete("Use GetReplicas(string keyspace, string table, byte[] partitionKey) for tablet-aware replica resolution.")]
         ICollection<HostShard> GetReplicas(string keyspace, byte[] partitionKey);
+
+        /// <summary>
+        /// Gets a collection of replicas for a given partition key on a given keyspace and table.
+        /// Tablet metadata is used when available, with token-map fallback otherwise.
+        /// </summary>
+        /// <param name="keyspace">The keyspace name.</param>
+        /// <param name="table">The table name.</param>
+        /// <param name="partitionKey">Byte array representing the partition key.</param>
+        /// <returns>A collection of replicas for the provided partition key.</returns>
+        ICollection<HostShard> GetReplicas(string keyspace, string table, byte[] partitionKey);
 
         /// <summary>
         ///  Shutdown this cluster instance. This closes all connections from all the

--- a/src/Cassandra/Metadata.cs
+++ b/src/Cassandra/Metadata.cs
@@ -274,21 +274,53 @@ namespace Cassandra
         }
 
         /// <summary>
-        /// Get the replicas for a given partition key and keyspace
+        /// Get the replicas for a given partition key, keyspace and table.
         /// </summary>
-        public ICollection<HostShard> GetReplicas(string keyspaceName, byte[] partitionKey)
+        /// <param name="keyspaceName">The keyspace name.</param>
+        /// <param name="tableName">The table name.</param>
+        /// <param name="partitionKey">Byte array representing the partition key.</param>
+        /// <returns>
+        /// A collection of replicas resolved using tablet metadata when available for the provided
+        /// keyspace and table, falling back to token-map resolution otherwise.
+        /// </returns>
+        public ICollection<HostShard> GetReplicas(string keyspaceName, string tableName, byte[] partitionKey)
         {
             if (_tokenMap == null)
             {
                 Metadata.Logger.Warning("Metadata.GetReplicas was called but there was no token map.");
                 return new HostShard[0];
             }
-            return _tokenMap.GetReplicas(keyspaceName, _tokenMap.Factory.Hash(partitionKey));
+
+            var token = _tokenMap.Factory.Hash(partitionKey);
+            if (!string.IsNullOrEmpty(keyspaceName) && !string.IsNullOrEmpty(tableName))
+            {
+                var tabletReplicas = TabletMap.GetReplicas(keyspaceName, tableName, token);
+                if (tabletReplicas != null && tabletReplicas.Count > 0)
+                {
+                    if (tabletReplicas is ICollection<HostShard> collection)
+                    {
+                        return collection;
+                    }
+                    return tabletReplicas.ToList();
+                }
+            }
+
+            return _tokenMap.GetReplicas(keyspaceName, token);
         }
 
+        /// <summary>
+        /// Get the replicas for a given partition key and keyspace.
+        /// </summary>
+        [Obsolete("Use GetReplicas(string keyspaceName, string tableName, byte[] partitionKey) for tablet-aware replica resolution.")]
+        public ICollection<HostShard> GetReplicas(string keyspaceName, byte[] partitionKey)
+        {
+            return GetReplicas(keyspaceName, null, partitionKey);
+        }
+
+        [Obsolete("Use GetReplicas(string keyspaceName, string tableName, byte[] partitionKey) for tablet-aware replica resolution.")]
         public ICollection<HostShard> GetReplicas(byte[] partitionKey)
         {
-            return GetReplicas(null, partitionKey);
+            return GetReplicas(null, null, partitionKey);
         }
 
         /// <summary>

--- a/src/Cassandra/Policies/TokenAwarePolicy.cs
+++ b/src/Cassandra/Policies/TokenAwarePolicy.cs
@@ -104,16 +104,7 @@ namespace Cassandra
 
             var keyspace = query.Keyspace ?? loggedKeyspace;
             var table = query.TableName;
-            IEnumerable<HostShard> replicas = null;
-            if (table != null)
-            {
-                var token = _cluster.Metadata.GetTokenFactory().Hash(routingKey.RawRoutingKey);
-                replicas = _cluster.Metadata.TabletMap.GetReplicas(keyspace, table, token);
-            }
-            if (replicas == null || !replicas.Any())
-            {
-                replicas = _cluster.GetReplicas(keyspace, routingKey.RawRoutingKey);
-            }
+            var replicas = _cluster.GetReplicas(keyspace, table, routingKey.RawRoutingKey) ?? new HostShard[0];
 
             var localReplicaSet = new HashSet<HostShard>();
             var localReplicaList = new List<HostShard>(replicas.Count());


### PR DESCRIPTION
The current replica resolution APIs exposed by Metadata:
```
public ICollection<HostShard> GetReplicas(string keyspaceName, byte[] partitionKey)
public ICollection<HostShard> GetReplicas(byte[] partitionKey)
```

Because the current C# APIs do not accept a table name, the tablet-based path cannot be used. This effectively forces replica resolution to assume vnode-based replication, which is incorrect for tablet-enabled clusters.

This PR introduces new API: 

```
public ICollection<HostShard> GetReplicas(string keyspaceName, string tableName, byte[] partitionKey)
```

Fixes: https://github.com/scylladb/csharp-driver/issues/197