### PR TITLE
Fix whitespace formatting in TokenTests.cs

### DIFF
--- a/src/Cassandra.Tests/TokenTests.cs
+++ b/src/Cassandra.Tests/TokenTests.cs
@@ -572,8 +572,7 @@ namespace Cassandra.Tests
                                     }
                                 }
                             }
-                            else
-                            if (j % 2 == 0)
+                            else if (j % 2 == 0)
                             {
                                 if (bag.TryTake(out var ksName))
                                 {


### PR DESCRIPTION
- Join split else/if into single else-if to satisfy dotnet format rules