### PR TITLE
Replace SimpleStrategy with NetworkTopologyStrategy in integration tests

### DIFF
--- a/src/Cassandra.IntegrationTests/Ado/AdoBasicTests.cs
+++ b/src/Cassandra.IntegrationTests/Ado/AdoBasicTests.cs
@@ -53,12 +53,13 @@ namespace Cassandra.IntegrationTests.Data
             var cmd = _connection.CreateCommand();
 
             string keyspaceName = "keyspace_ado_1";
-            cmd.CommandText = string.Format(TestUtils.CreateKeyspaceSimpleFormat, keyspaceName, 3);
+            cmd.CommandText = string.Format(TestUtils.CreateKeyspaceGenericFormat, keyspaceName, "NetworkTopologyStrategy",
+                                              string.Format("'replication_factor' : {0}", 3));
             cmd.ExecuteNonQuery();
 
             VerifyStatement(
                 QueryType.Query,
-                $"CREATE KEYSPACE \"{keyspaceName}\" WITH replication = {{ 'class' : 'SimpleStrategy', 'replication_factor' : {3} }}",
+                $"CREATE KEYSPACE {keyspaceName} WITH replication = {{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : {3} }}",
                 1);
 
             _connection.ChangeDatabase(keyspaceName);

--- a/src/Cassandra.IntegrationTests/Core/CollectionsNestedTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/CollectionsNestedTests.cs
@@ -324,7 +324,7 @@ namespace Cassandra.IntegrationTests.Core
 
         private void SetupForFrozenNestedCollectionTest(ISession session, string keyspaceName, string fqTableName)
         {
-            session.Execute(string.Format("CREATE KEYSPACE IF NOT EXISTS {0} WITH replication = {1};", keyspaceName, "{'class': 'SimpleStrategy', 'replication_factor' : 1}"));
+            session.Execute(string.Format("CREATE KEYSPACE IF NOT EXISTS {0} WITH replication = {1};", keyspaceName, "{'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}"));
             session.Execute(string.Format("CREATE TABLE IF NOT EXISTS {0} " +
                                           "(id int primary key, " +
                                           "map1 map<text, frozen<list<text>>>," +

--- a/src/Cassandra.IntegrationTests/Core/ConnectionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ConnectionTests.cs
@@ -294,7 +294,7 @@ namespace Cassandra.IntegrationTests.Core
             using (var connection = CreateConnection())
             {
                 await connection.Open().ConfigureAwait(false);
-                await Query(connection, "CREATE KEYSPACE ks_conn_consume WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}")
+                await Query(connection, "CREATE KEYSPACE ks_conn_consume WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}")
                     .ConfigureAwait(false);
 
                 await Query(connection, "CREATE TABLE ks_conn_consume.tbl1 (id uuid primary key)").ConfigureAwait(false);
@@ -516,9 +516,9 @@ namespace Cassandra.IntegrationTests.Core
         public async Task SetKeyspace_Parallel_Calls_Serially_Executes()
         {
             const string queryKs1 = "create keyspace if not exists ks_to_switch_p1 WITH replication = " +
-                                    "{'class': 'SimpleStrategy', 'replication_factor' : 1}";
+                                    "{'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}";
             const string queryKs2 = "create keyspace if not exists ks_to_switch_p2 WITH replication = " +
-                                    "{'class': 'SimpleStrategy', 'replication_factor' : 1}";
+                                    "{'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}";
             // ReSharper disable AccessToDisposedClosure, AccessToModifiedClosure
             using (var connection = CreateConnection())
             {
@@ -565,8 +565,8 @@ namespace Cassandra.IntegrationTests.Core
         [Test]
         public void SetKeyspace_Serial_Calls_Serially_Executes()
         {
-            const string queryKs1 = "create keyspace ks_to_switch_s1 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}";
-            const string queryKs2 = "create keyspace ks_to_switch_s2 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}";
+            const string queryKs1 = "create keyspace ks_to_switch_s1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}";
+            const string queryKs2 = "create keyspace ks_to_switch_s2 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}";
             using (var connection = CreateConnection())
             {
                 connection.Open().Wait();
@@ -606,7 +606,7 @@ namespace Cassandra.IntegrationTests.Core
         public void SetKeyspace_When_Disposing_Faults_Task()
         {
             //Invoke multiple times, as it involves different threads and can be scheduled differently
-            const string queryKs = "create keyspace ks_to_switch_when1 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}";
+            const string queryKs = "create keyspace ks_to_switch_when1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}";
             using (var connection = CreateConnection())
             {
                 connection.Open().Wait();

--- a/src/Cassandra.IntegrationTests/Core/MetadataTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/MetadataTests.cs
@@ -52,10 +52,10 @@ namespace Cassandra.IntegrationTests.Core
             Assert.AreEqual(1, cluster.GetReplicas("ks2", new byte[] { 0, 0, 0, 1 }).Count);
 
             const string createKeyspaceQuery = "CREATE KEYSPACE {0} WITH replication = {{ 'class' : '{1}', {2} }}";
-            session.Execute(string.Format(createKeyspaceQuery, "ks1", "SimpleStrategy", "'replication_factor' : 1"));
-            session.Execute(string.Format(createKeyspaceQuery, "ks2", "SimpleStrategy", "'replication_factor' : 3"));
+            session.Execute(string.Format(createKeyspaceQuery, "ks1", "NetworkTopologyStrategy", "'replication_factor' : 1"));
+            session.Execute(string.Format(createKeyspaceQuery, "ks2", "NetworkTopologyStrategy", "'replication_factor' : 3"));
             session.Execute(string.Format(createKeyspaceQuery, "ks3", "NetworkTopologyStrategy", "'dc1' : 1"));
-            session.Execute(string.Format(createKeyspaceQuery, "\"KS4\"", "SimpleStrategy", "'replication_factor' : 3"));
+            session.Execute(string.Format(createKeyspaceQuery, "\"KS4\"", "NetworkTopologyStrategy", "'replication_factor' : 3"));
             //Let the magic happen
             Thread.Sleep(5000);
             Assert.Greater(cluster.Metadata.GetKeyspaces().Count, initialLength);
@@ -168,7 +168,7 @@ namespace Cassandra.IntegrationTests.Core
             TestHelper.Invoke(() => session.Execute("SELECT key FROM system.local WHERE key='local'"), 10);
             Assert.True(cluster.AllHosts().All(h => h.IsConsiderablyUp));
             //When the host of the control connection is used
-            //It can result that event UP is not fired as it is not received by the control connection (it reconnected but missed the event) 
+            //It can result that event UP is not fired as it is not received by the control connection (it reconnected but missed the event)
             Assert.True(upEventFired || useControlConnectionHost);
         }
 
@@ -262,17 +262,18 @@ namespace Cassandra.IntegrationTests.Core
         }
 
         [Test]
-        public void CheckSimpleStrategyKeyspace()
+        public void CheckNetworkTopologyStrategyKeyspace_SingleDatacenter()
         {
             ITestCluster testCluster = TestClusterManager.GetNonShareableTestCluster(DefaultNodeCount);
             var session = testCluster.Session;
             bool durableWrites = Randomm.Instance.NextBoolean();
             string keyspaceName = TestUtils.GetUniqueKeyspaceName();
 
-            string strategyClass = ReplicationStrategies.SimpleStrategy;
+            string strategyClass = ReplicationStrategies.NetworkTopologyStrategy;
             int replicationFactor = Randomm.Instance.Next(1, 21);
             session.CreateKeyspace(keyspaceName,
-                ReplicationStrategies.CreateSimpleStrategyReplicationProperty(replicationFactor),
+                ReplicationStrategies.CreateNetworkTopologyStrategyReplicationProperty(
+                    new Dictionary<string, int> { { "replication_factor", replicationFactor } }),
                 durableWrites);
             session.ChangeKeyspace(keyspaceName);
 
@@ -340,11 +341,11 @@ namespace Cassandra.IntegrationTests.Core
             ITestCluster testCluster = TestClusterManager.GetNonShareableTestCluster(DefaultNodeCount);
             var session = testCluster.Session;
 
-            const string strategyClass = "SimpleStrategy";
+            const string strategyClass = "NetworkTopologyStrategy";
             const bool durableWrites = false;
             const int replicationFactor = 1;
             string cql = string.Format(@"
-                        CREATE KEYSPACE {0} 
+                        CREATE KEYSPACE {0}
                         WITH replication = {{ 'class' : '{1}', 'replication_factor' : {2} }}
                         AND durable_writes={3};", keyspaceName, strategyClass, 1, durableWrites);
             session.Execute(cql);
@@ -504,11 +505,11 @@ namespace Cassandra.IntegrationTests.Core
             var testCluster = TestClusterManager.GetNonShareableTestCluster(3, DefaultMaxClusterCreateRetries, true, false);
             var queries = new[]
             {
-                "CREATE KEYSPACE ks1 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3};",
+                "CREATE KEYSPACE ks1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3};",
                 "CREATE TABLE ks1.tbl1 (id uuid PRIMARY KEY, value text)",
                 "SELECT * FROM ks1.tbl1",
                 "SELECT * FROM ks1.tbl1 where id = d54cb06d-d168-45a0-b1b2-9f5c75435d3d",
-                "CREATE KEYSPACE ks2 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3};",
+                "CREATE KEYSPACE ks2 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3};",
                 "CREATE TABLE ks2.tbl2 (id uuid PRIMARY KEY, value text)",
                 "SELECT * FROM ks2.tbl2",
                 "SELECT * FROM ks2.tbl2",
@@ -545,22 +546,22 @@ namespace Cassandra.IntegrationTests.Core
         }
 
         /// Tests that materialized view metadata is being properly retrieved
-        /// 
+        ///
         /// GetMaterializedView_Should_Retrieve_View_Metadata tests that materialized view metadata is being properly populated by the driver.
         /// It first creates a base table with some sample columns, and a materialized view based on those columns. It then verifies the various metadata
-        /// associated with the view. 
-        /// 
+        /// associated with the view.
+        ///
         /// @since 3.0.0
         /// @jira_ticket CSHARP-348
         /// @expected_result Materialized view metadata is properly populated
-        /// 
+        ///
         /// @test_category metadata
         [Test, TestCassandraVersion(3, 0)]
         public void GetMaterializedView_Should_Retrieve_View_Metadata()
         {
             var queries = new[]
             {
-                "CREATE KEYSPACE ks_view_meta WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3}",
+                "CREATE KEYSPACE ks_view_meta WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}",
                 "CREATE TABLE ks_view_meta.scores (user TEXT, game TEXT, year INT, month INT, day INT, score INT, PRIMARY KEY (user, game, year, month, day))",
                 "CREATE MATERIALIZED VIEW ks_view_meta.dailyhigh AS SELECT user FROM scores WHERE game IS NOT NULL AND year IS NOT NULL AND month IS NOT NULL AND day IS NOT NULL AND score IS NOT NULL AND user IS NOT NULL PRIMARY KEY ((game, year, month, day), score, user) WITH CLUSTERING ORDER BY (score DESC)"
             };
@@ -603,22 +604,22 @@ namespace Cassandra.IntegrationTests.Core
         }
 
         /// Tests that materialized view metadata with quoted identifiers is being retrieved
-        /// 
-        /// MaterializedView_Should_Retrieve_View_Metadata_Quoted_Identifiers tests that materialized view metadata with quoated identifiers is being 
+        ///
+        /// MaterializedView_Should_Retrieve_View_Metadata_Quoted_Identifiers tests that materialized view metadata with quoated identifiers is being
         /// properly populated by the driver. It first creates a base table with some sample columns, where these columns have quoted identifers as their name.
-        /// It then creates a materialized view based on those columns. It then verifies the various metadata associated with the view. 
-        /// 
+        /// It then creates a materialized view based on those columns. It then verifies the various metadata associated with the view.
+        ///
         /// @since 3.0.0
         /// @jira_ticket CSHARP-348
         /// @expected_result Materialized view metadata is properly populated
-        /// 
+        ///
         /// @test_category metadata
         [Test, TestCassandraVersion(3, 0)]
         public void MaterializedView_Should_Retrieve_View_Metadata_Quoted_Identifiers()
         {
             var queries = new[]
             {
-                "CREATE KEYSPACE ks_view_meta2 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3}",
+                "CREATE KEYSPACE ks_view_meta2 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}",
                 @"CREATE TABLE ks_view_meta2.t1 (""theKey"" INT, ""the;Clustering"" INT, ""the Value"" INT, PRIMARY KEY (""theKey"", ""the;Clustering""))",
                 @"CREATE MATERIALIZED VIEW ks_view_meta2.mv1 AS SELECT ""theKey"", ""the;Clustering"", ""the Value"" FROM t1 WHERE ""theKey"" IS NOT NULL AND ""the;Clustering"" IS NOT NULL AND ""the Value"" IS NOT NULL PRIMARY KEY (""theKey"", ""the;Clustering"")"
             };

--- a/src/Cassandra.IntegrationTests/Core/MultiThreadingTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/MultiThreadingTests.cs
@@ -48,9 +48,9 @@ namespace Cassandra.IntegrationTests.Core
         }
 
         /** name of test: ParallelInsertTest
-         * 
+         *
          * @param nothingActually.
-         * 
+         *
          */
         [Test]
         public void ParallelInsertTest()
@@ -59,7 +59,7 @@ namespace Cassandra.IntegrationTests.Core
             ISession localSession = localCluster.Connect();
             string keyspaceName = "kp_pi1_" + Randomm.RandomAlphaNum(10);
 
-            localSession.Execute(string.Format(@"CREATE KEYSPACE {0} WITH replication = {{ 'class' : 'SimpleStrategy', 'replication_factor' : 2 }};", keyspaceName));
+            localSession.Execute(string.Format(@"CREATE KEYSPACE {0} WITH replication = {{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 2 }};", keyspaceName));
 
             TestUtils.WaitForSchemaAgreement(localCluster);
             localSession.ChangeKeyspace(keyspaceName);
@@ -105,7 +105,7 @@ namespace Cassandra.IntegrationTests.Core
                             }
 
                             ar[i] = localSession.BeginExecute(string.Format(@"
-                                INSERT INTO {0} (tweet_id, author, isok, body) 
+                                INSERT INTO {0} (tweet_id, author, isok, body)
                                 VALUES ({1},'test{2}',{3},'body{2}');",
                                 tableName, Guid.NewGuid(), i, i % 2 == 0 ? "false" : "true"), ConsistencyLevel.One, null, null);
                             Interlocked.MemoryBarrier();
@@ -229,8 +229,8 @@ namespace Cassandra.IntegrationTests.Core
             ISession localSession = localCluster.Connect();
             string keyspaceName = "kp_mat_" + Randomm.RandomAlphaNum(8);
             localSession.Execute(
-                string.Format(@"CREATE KEYSPACE {0} 
-                    WITH replication = {{ 'class' : 'SimpleStrategy', 'replication_factor' : 2 }};"
+                string.Format(@"CREATE KEYSPACE {0}
+                    WITH replication = {{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 2 }};"
                                 , keyspaceName));
             localSession.ChangeKeyspace(keyspaceName);
 
@@ -295,7 +295,7 @@ namespace Cassandra.IntegrationTests.Core
             ISession localSession = localCluster.Connect();
             string keyspaceName = "keyspace" + Guid.NewGuid().ToString("N").ToLower();
             localSession.Execute(
-                    string.Format(@"CREATE KEYSPACE {0} WITH replication = {{ 'class' : 'SimpleStrategy', 'replication_factor' : 2 }};", keyspaceName));
+                    string.Format(@"CREATE KEYSPACE {0} WITH replication = {{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 2 }};", keyspaceName));
             localSession.ChangeKeyspace(keyspaceName);
 
             string tableName = "table" + Guid.NewGuid().ToString("N").ToLower();

--- a/src/Cassandra.IntegrationTests/Core/PoolTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PoolTests.cs
@@ -305,7 +305,7 @@ namespace Cassandra.IntegrationTests.Core
             {
                 var session = cluster.Connect();
                 //Will wait for all the nodes to have the same schema
-                session.Execute("CREATE KEYSPACE ks1 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3}");
+                session.Execute("CREATE KEYSPACE ks1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}");
             }
         }
 
@@ -324,7 +324,7 @@ namespace Cassandra.IntegrationTests.Core
             {
                 var session = cluster.Connect();
                 //Will wait for all the nodes to have the same schema
-                session.Execute("CREATE KEYSPACE ks1 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3}");
+                session.Execute("CREATE KEYSPACE ks1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}");
                 session.ChangeKeyspace("ks1");
                 TestHelper.ParallelInvoke(() =>
                 {

--- a/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs
@@ -202,7 +202,7 @@ namespace Cassandra.IntegrationTests.Core
 
                 // Create schema and insert data
                 session1.Execute(
-                    "CREATE KEYSPACE ks1 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}");
+                    "CREATE KEYSPACE ks1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}");
                 session1.ChangeKeyspace("ks1");
                 session2.ChangeKeyspace("ks1");
                 session1.Execute("CREATE TABLE table1 (id int PRIMARY KEY, a text, c text)");
@@ -730,7 +730,7 @@ namespace Cassandra.IntegrationTests.Core
                 .Build())
             {
                 var session = localCluster.Connect("system");
-                session.Execute("CREATE KEYSPACE bound_changeks_test WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3}");
+                session.Execute("CREATE KEYSPACE bound_changeks_test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}");
                 TestUtils.WaitForSchemaAgreement(localCluster);
                 var ps = session.Prepare("SELECT * FROM system.local WHERE key='local'");
                 session.ChangeKeyspace("bound_changeks_test");

--- a/src/Cassandra.IntegrationTests/Core/SchemaMetadataTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SchemaMetadataTests.cs
@@ -436,7 +436,7 @@ namespace Cassandra.IntegrationTests.Core
         {
             var queries = new[]
             {
-                "CREATE KEYSPACE IF NOT EXISTS ks_view_meta3 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3}",
+                "CREATE KEYSPACE IF NOT EXISTS ks_view_meta3 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}",
                 "CREATE TABLE IF NOT EXISTS ks_view_meta3.scores (user TEXT, game TEXT, year INT, month INT, day INT, score INT, PRIMARY KEY (user, game, year, month, day))",
                 "CREATE MATERIALIZED VIEW IF NOT EXISTS ks_view_meta3.monthlyhigh AS SELECT user, game, year, month, score, day FROM scores WHERE game IS NOT NULL AND year IS NOT NULL AND month IS NOT NULL AND score IS NOT NULL AND user IS NOT NULL AND day IS NOT NULL PRIMARY KEY ((game, year, month), score, user, day) WITH CLUSTERING ORDER BY (score DESC, user DESC, day DESC) AND compaction = { 'class' : 'SizeTieredCompactionStrategy' }"
             };
@@ -489,7 +489,7 @@ namespace Cassandra.IntegrationTests.Core
         {
             var queries = new[]
             {
-                "CREATE KEYSPACE IF NOT EXISTS ks_view_meta4 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3}",
+                "CREATE KEYSPACE IF NOT EXISTS ks_view_meta4 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}",
                 "CREATE TABLE IF NOT EXISTS ks_view_meta4.scores (user TEXT, game TEXT, year INT, month INT, day INT, score INT, PRIMARY KEY (user, game, year, month, day))",
                 "CREATE MATERIALIZED VIEW IF NOT EXISTS ks_view_meta4.dailyhigh AS SELECT user, game, year, month, day, score FROM scores WHERE game IS NOT NULL AND year IS NOT NULL AND month IS NOT NULL AND day IS NOT NULL AND score IS NOT NULL AND user IS NOT NULL PRIMARY KEY ((game, year, month, day), score, user) WITH CLUSTERING ORDER BY (score DESC, user DESC)",
                 "CREATE MATERIALIZED VIEW IF NOT EXISTS ks_view_meta4.alltimehigh AS SELECT * FROM scores WHERE game IS NOT NULL AND year IS NOT NULL AND month IS NOT NULL AND day IS NOT NULL AND score IS NOT NULL AND user IS NOT NULL PRIMARY KEY (game, score, year, month, day, user) WITH CLUSTERING ORDER BY (score DESC, year DESC, month DESC, day DESC, user DESC)"

--- a/src/Cassandra.IntegrationTests/Core/StressTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/StressTests.cs
@@ -45,7 +45,7 @@ namespace Cassandra.IntegrationTests.Core
                 var session = cluster.Connect();
                 var uniqueKsName = "keyspace_" + Randomm.RandomAlphaNum(10);
                 session.Execute(@"CREATE KEYSPACE " + uniqueKsName +
-                                " WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3};");
+                                " WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3};");
                 session.ChangeKeyspace(uniqueKsName);
 
                 var tableName = "table_" + Guid.NewGuid().ToString("N").ToLower();
@@ -102,7 +102,7 @@ namespace Cassandra.IntegrationTests.Core
                 var session = cluster.Connect();
                 var uniqueKsName = "keyspace_" + Randomm.RandomAlphaNum(10);
                 session.Execute(@"CREATE KEYSPACE " + uniqueKsName +
-                    " WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3};");
+                    " WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3};");
                 session.ChangeKeyspace(uniqueKsName);
 
                 var tableName = "table_" + Guid.NewGuid().ToString("N").ToLower();

--- a/src/Cassandra.IntegrationTests/Core/UdfTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/UdfTests.cs
@@ -69,7 +69,7 @@ namespace Cassandra.IntegrationTests.Core
                 var session = cluster.Connect();
                 var queries = new List<string>
                 {
-                    "CREATE KEYSPACE  ks_udf WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}",
+                    "CREATE KEYSPACE  ks_udf WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}",
                     $"CREATE FUNCTION  ks_udf.return_one() RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE {udfLanguage} AS 'return 1;'",
                     $"CREATE FUNCTION  ks_udf.plus(s int, v int) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE {udfLanguage} AS 'return s+v;'",
                     $"CREATE FUNCTION  ks_udf.plus(s bigint, v bigint) RETURNS NULL ON NULL INPUT RETURNS bigint LANGUAGE {udfLanguage} AS 'return s+v;'",

--- a/src/Cassandra.IntegrationTests/Mapping/Tests/InsertTests.cs
+++ b/src/Cassandra.IntegrationTests/Mapping/Tests/InsertTests.cs
@@ -266,7 +266,7 @@ namespace Cassandra.IntegrationTests.Mapping.Tests
         }
 
         /// <summary>
-        /// Successfully insert a new record into a table that was created with fluent mapping, 
+        /// Successfully insert a new record into a table that was created with fluent mapping,
         /// using Session.Execute to insert an Insert object created with table.Insert()
         /// </summary>
         [Test, TestCassandraVersion(2, 0)]
@@ -304,7 +304,7 @@ namespace Cassandra.IntegrationTests.Mapping.Tests
         }
 
         /// <summary>
-        /// By default Linq preserves class param casing, but cqlpoco does not, 
+        /// By default Linq preserves class param casing, but cqlpoco does not,
         /// so expect "unconfigured columnfamily" when trying to insert via cqlpoco using default settings
         /// This also validates that a private class can be used by the CqlPoco client
         /// </summary>
@@ -476,7 +476,7 @@ namespace Cassandra.IntegrationTests.Mapping.Tests
 
         /// Tests if timestamp is set on CqlQueryOptions.
         ///
-        /// The TIMESTAMP input is in microseconds. If not specified, the time (in microseconds) that the write occurred to the column is used. 
+        /// The TIMESTAMP input is in microseconds. If not specified, the time (in microseconds) that the write occurred to the column is used.
         /// when all nodes in the cluster is down, given a set ReadTimeoutMillis of 3 seconds.
         ///
         /// @since 2.1
@@ -557,8 +557,8 @@ namespace Cassandra.IntegrationTests.Mapping.Tests
                 var session = cluster.Connect();
                 session.CreateKeyspace(anotherKeyspace, new Dictionary<string, string>
                 {
-                    { "class", "SimpleStrategy"},
-                    { "replication_factor", "3"}
+                    { "class", "NetworkTopologyStrategy" },
+                    { "replication_factor", "1"}
                 });
                 session.ChangeKeyspace(anotherKeyspace);
 
@@ -593,7 +593,7 @@ namespace Cassandra.IntegrationTests.Mapping.Tests
                 var batch = mapper.CreateBatch();
                 batch.Insert(user1);
                 batch.Insert(user2);
-                var consistency = ConsistencyLevel.All;
+                var consistency = ConsistencyLevel.Three;
                 batch.WithOptions(o => o.SetConsistencyLevel(consistency));
                 //Timestamp for BATCH request is supported in Cassandra 2.1 or above.
                 if (TestClusterManager.CassandraVersion > Version.Parse("2.1"))
@@ -602,8 +602,8 @@ namespace Cassandra.IntegrationTests.Mapping.Tests
                     batch.WithOptions(o => o.SetTimestamp(timestamp));
                 }
                 var ex = Assert.Throws<UnavailableException>(() => mapper.Execute(batch));
-                Assert.AreEqual(ConsistencyLevel.All, ex.Consistency,
-                            "Consistency level of batch exception should be the same as specified at CqlQueryOptions: ALL");
+                Assert.AreEqual(ConsistencyLevel.Three, ex.Consistency,
+                            "Consistency level of batch exception should be the same as specified at CqlQueryOptions: THREE");
                 Assert.AreEqual(3, ex.RequiredReplicas);
                 Assert.AreEqual(1, ex.AliveReplicas);
             }

--- a/src/Cassandra.IntegrationTests/MetadataTests/TokenMapSchemaChangeMetadataSyncTests.cs
+++ b/src/Cassandra.IntegrationTests/MetadataTests/TokenMapSchemaChangeMetadataSyncTests.cs
@@ -70,7 +70,7 @@ namespace Cassandra.IntegrationTests.MetadataTests
                 Assert.AreEqual(3, newCluster.Metadata.Hosts.Count);
 
                 Assert.IsNull(newCluster.Metadata.TokenToReplicasMap.GetByKeyspace(keyspaceName));
-                var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 3}}";
+                var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}}";
 
                 newSession.Execute(createKeyspaceCql);
                 TestUtils.WaitForSchemaAgreement(newCluster);
@@ -86,7 +86,7 @@ namespace Cassandra.IntegrationTests.MetadataTests
         public void TokenMap_Should_NotUpdateExistingTokenMap_When_KeyspaceIsRemoved()
         {
             var keyspaceName = TestUtils.GetUniqueKeyspaceName().ToLower();
-            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 3}}";
+            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}}";
             _session.Execute(createKeyspaceCql);
             TestUtils.WaitForSchemaAgreement(_cluster);
 
@@ -111,7 +111,7 @@ namespace Cassandra.IntegrationTests.MetadataTests
         public void TokenMap_Should_NotUpdateExistingTokenMap_When_KeyspaceIsChanged()
         {
             var keyspaceName = TestUtils.GetUniqueKeyspaceName().ToLower();
-            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 3}}";
+            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}}";
             _session.Execute(createKeyspaceCql);
             TestUtils.WaitForSchemaAgreement(_cluster);
 
@@ -131,7 +131,7 @@ namespace Cassandra.IntegrationTests.MetadataTests
 
                 Assert.AreEqual(3, newCluster.Metadata.Hosts.Count(h => h.IsUp));
                 var oldTokenMap = newCluster.Metadata.TokenToReplicasMap;
-                var alterKeyspaceCql = $"ALTER KEYSPACE {keyspaceName} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 2}}";
+                var alterKeyspaceCql = $"ALTER KEYSPACE {keyspaceName} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 2}}";
                 newSession.Execute(alterKeyspaceCql);
                 TestUtils.WaitForSchemaAgreement(newCluster);
                 TestHelper.RetryAssert(() =>
@@ -150,11 +150,11 @@ namespace Cassandra.IntegrationTests.MetadataTests
         public async Task TokenMap_Should_RefreshTokenMapForSingleKeyspace_When_RefreshSchemaWithKeyspaceIsCalled()
         {
             var keyspaceName = TestUtils.GetUniqueKeyspaceName().ToLower();
-            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 3}}";
+            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}}";
             _session.Execute(createKeyspaceCql);
             TestUtils.WaitForSchemaAgreement(_cluster);
             keyspaceName = TestUtils.GetUniqueKeyspaceName().ToLower();
-            createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 3}}";
+            createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}}";
             _session.Execute(createKeyspaceCql);
             TestUtils.WaitForSchemaAgreement(_cluster);
 
@@ -189,11 +189,11 @@ namespace Cassandra.IntegrationTests.MetadataTests
         public async Task TokenMap_Should_RefreshTokenMapForAllKeyspaces_When_RefreshSchemaWithoutKeyspaceIsCalled()
         {
             var keyspaceName1 = TestUtils.GetUniqueKeyspaceName().ToLower();
-            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName1} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 3}}";
+            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName1} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}}";
             _session.Execute(createKeyspaceCql);
             TestUtils.WaitForSchemaAgreement(_cluster);
             var keyspaceName = TestUtils.GetUniqueKeyspaceName().ToLower();
-            createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 3}}";
+            createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}}";
             _session.Execute(createKeyspaceCql);
             TestUtils.WaitForSchemaAgreement(_cluster);
 

--- a/src/Cassandra.IntegrationTests/MetadataTests/TokenMapSchemaChangeTests.cs
+++ b/src/Cassandra.IntegrationTests/MetadataTests/TokenMapSchemaChangeTests.cs
@@ -43,7 +43,7 @@ namespace Cassandra.IntegrationTests.MetadataTests
             Assert.AreEqual(3, newCluster.Metadata.Hosts.Count);
 
             Assert.IsNull(newCluster.Metadata.TokenToReplicasMap.GetByKeyspace(keyspaceName));
-            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 3}}";
+            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}}";
 
             newSession.Execute(createKeyspaceCql);
             TestUtils.WaitForSchemaAgreement(newCluster);
@@ -65,7 +65,7 @@ namespace Cassandra.IntegrationTests.MetadataTests
         public void TokenMap_Should_UpdateExistingTokenMap_When_KeyspaceIsRemoved()
         {
             var keyspaceName = TestUtils.GetUniqueKeyspaceName().ToLower();
-            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 3}}";
+            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}}";
             Session.Execute(createKeyspaceCql);
             TestUtils.WaitForSchemaAgreement(Cluster);
 
@@ -86,7 +86,7 @@ namespace Cassandra.IntegrationTests.MetadataTests
         public void TokenMap_Should_UpdateExistingTokenMap_When_KeyspaceIsChanged()
         {
             var keyspaceName = TestUtils.GetUniqueKeyspaceName().ToLower();
-            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 3}}";
+            var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}}";
             Session.Execute(createKeyspaceCql);
             TestUtils.WaitForSchemaAgreement(Cluster);
 
@@ -101,7 +101,7 @@ namespace Cassandra.IntegrationTests.MetadataTests
 
             Assert.AreEqual(3, newCluster.Metadata.Hosts.Count(h => h.IsUp));
             var oldTokenMap = newCluster.Metadata.TokenToReplicasMap;
-            var alterKeyspaceCql = $"ALTER KEYSPACE {keyspaceName} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 2}}";
+            var alterKeyspaceCql = $"ALTER KEYSPACE {keyspaceName} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 2}}";
             newSession.Execute(alterKeyspaceCql);
             TestUtils.WaitForSchemaAgreement(newCluster);
             TestHelper.RetryAssert(() =>

--- a/src/Cassandra.IntegrationTests/MetadataTests/TokenMapTopologyChangeTests.cs
+++ b/src/Cassandra.IntegrationTests/MetadataTests/TokenMapTopologyChangeTests.cs
@@ -61,7 +61,7 @@ namespace Cassandra.IntegrationTests.MetadataTests
                 var sessionNotSync = ClusterObjNotSync.Connect();
                 var sessionSync = ClusterObjSync.Connect();
 
-                var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 3}}";
+                var createKeyspaceCql = $"CREATE KEYSPACE {keyspaceName} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}}";
                 sessionNotSync.Execute(createKeyspaceCql);
 
                 TestUtils.WaitForSchemaAgreement(ClusterObjNotSync);

--- a/src/Cassandra.IntegrationTests/Policies/Tests/LoadBalancingPolicyShortTests.cs
+++ b/src/Cassandra.IntegrationTests/Policies/Tests/LoadBalancingPolicyShortTests.cs
@@ -57,8 +57,8 @@ namespace Cassandra.IntegrationTests.Policies.Tests
             }
         }
         /// <summary>
-        /// Validate that no hops occur when inserting into a single partition 
-        /// 
+        /// Validate that no hops occur when inserting into a single partition
+        ///
         /// @test_category load_balancing:dc_aware,round_robin
         /// @test_category replication_strategy
         /// </summary>
@@ -91,8 +91,8 @@ namespace Cassandra.IntegrationTests.Policies.Tests
         }
 
         /// <summary>
-        /// Validate that no hops occur when inserting GUID values into the key 
-        /// 
+        /// Validate that no hops occur when inserting GUID values into the key
+        ///
         /// @test_category load_balancing:dc_aware,round_robin
         /// @test_category replication_strategy
         /// </summary>
@@ -128,8 +128,8 @@ namespace Cassandra.IntegrationTests.Policies.Tests
         }
 
         /// <summary>
-        /// Validate that no hops occur when inserting into a composite key 
-        /// 
+        /// Validate that no hops occur when inserting into a composite key
+        ///
         /// @test_category load_balancing:dc_aware,round_robin
         /// @test_category replication_strategy
         /// </summary>
@@ -202,8 +202,8 @@ namespace Cassandra.IntegrationTests.Policies.Tests
         }
 
         /// <summary>
-        /// Validate that no hops occur when inserting string values via a prepared statement 
-        /// 
+        /// Validate that no hops occur when inserting string values via a prepared statement
+        ///
         /// @test_category load_balancing:dc_aware,round_robin
         /// @test_category replication_strategy
         /// @test_category prepared_statements
@@ -242,8 +242,8 @@ namespace Cassandra.IntegrationTests.Policies.Tests
         }
 
         /// <summary>
-        /// Validate that no hops occur when inserting int values via a prepared statement 
-        /// 
+        /// Validate that no hops occur when inserting int values via a prepared statement
+        ///
         /// @test_category load_balancing:dc_aware,round_robin
         /// @test_category replication_strategy
         /// @test_category prepared_statements
@@ -279,8 +279,8 @@ namespace Cassandra.IntegrationTests.Policies.Tests
         }
 
         /// <summary>
-        /// Validate that hops occur when the wrong partition is targeted 
-        /// 
+        /// Validate that hops occur when the wrong partition is targeted
+        ///
         /// @test_category load_balancing:dc_aware,round_robin
         /// @test_category replication_strategy
         /// </summary>
@@ -325,7 +325,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                 var session = cluster.Connect();
                 Assert.AreEqual(256, cluster.AllHosts().First().Tokens.Count());
                 var ks = TestUtils.GetUniqueKeyspaceName();
-                session.Execute($"CREATE KEYSPACE \"{ks}\" WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 1}}");
+                session.Execute($"CREATE KEYSPACE \"{ks}\" WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}} AND tablets = {{'enabled': false}}");
                 session.ChangeKeyspace(ks);
                 session.Execute("CREATE TABLE tbl1 (id uuid primary key)");
                 var ps = session.Prepare("INSERT INTO tbl1 (id) VALUES (?)");
@@ -365,7 +365,7 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                 // Connect without a keyspace
                 var session = cluster.Connect();
                 var ks = TestUtils.GetUniqueKeyspaceName();
-                session.Execute($"CREATE KEYSPACE \"{ks}\" WITH replication = {{'class': 'SimpleStrategy', 'replication_factor' : 2}}");
+                session.Execute($"CREATE KEYSPACE \"{ks}\" WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 2}} AND tablets = {{'enabled': false}}");
                 session.ChangeKeyspace(ks);
                 session.Execute($"CREATE TABLE tbl1 (id uuid primary key)");
                 var ps = session.Prepare($"INSERT INTO tbl1 (id) VALUES (?)");

--- a/src/Cassandra.IntegrationTests/Policies/Tests/LoadBalancingPolicyShortTests.cs
+++ b/src/Cassandra.IntegrationTests/Policies/Tests/LoadBalancingPolicyShortTests.cs
@@ -325,7 +325,14 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                 var session = cluster.Connect();
                 Assert.AreEqual(256, cluster.AllHosts().First().Tokens.Count());
                 var ks = TestUtils.GetUniqueKeyspaceName();
-                session.Execute($"CREATE KEYSPACE \"{ks}\" WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}} AND tablets = {{'enabled': false}}");
+                if (TestClusterManager.IsScylla)
+                {
+                    session.Execute($"CREATE KEYSPACE \"{ks}\" WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}} AND tablets = {{'enabled': false}}");
+                }
+                else
+                {
+                    session.Execute($"CREATE KEYSPACE \"{ks}\" WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}}");
+                }
                 session.ChangeKeyspace(ks);
                 session.Execute("CREATE TABLE tbl1 (id uuid primary key)");
                 var ps = session.Prepare("INSERT INTO tbl1 (id) VALUES (?)");
@@ -365,7 +372,14 @@ namespace Cassandra.IntegrationTests.Policies.Tests
                 // Connect without a keyspace
                 var session = cluster.Connect();
                 var ks = TestUtils.GetUniqueKeyspaceName();
-                session.Execute($"CREATE KEYSPACE \"{ks}\" WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 2}} AND tablets = {{'enabled': false}}");
+                if (TestClusterManager.IsScylla)
+                {
+                    session.Execute($"CREATE KEYSPACE \"{ks}\" WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 2}} AND tablets = {{'enabled': false}}");
+                }
+                else
+                {
+                    session.Execute($"CREATE KEYSPACE \"{ks}\" WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor' : 2}}");
+                }
                 session.ChangeKeyspace(ks);
                 session.Execute($"CREATE TABLE tbl1 (id uuid primary key)");
                 var ps = session.Prepare($"INSERT INTO tbl1 (id) VALUES (?)");

--- a/src/Cassandra.IntegrationTests/ScyllaLwtTests.cs
+++ b/src/Cassandra.IntegrationTests/ScyllaLwtTests.cs
@@ -72,7 +72,7 @@ namespace Cassandra.IntegrationTests
             Assert.True(statementLWT.IsLwt, "LWT statement should be detected as LWT");
         }
 
-        [Test]
+        [Test, TestScyllaVersion(2026, 1)]
         public void Should_Use_Only_One_Node_When_LWT_Detected()
         {
             _realCluster = TestClusterManager.CreateNew(3);
@@ -84,7 +84,7 @@ namespace Cassandra.IntegrationTests
 
             // Create keyspace and table
             session.Execute("DROP KEYSPACE IF EXISTS lwt_test");
-            session.Execute($"CREATE KEYSPACE lwt_test WITH replication = {{'class': 'SimpleStrategy', 'replication_factor': 3}}");
+            session.Execute($"CREATE KEYSPACE lwt_test WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 3}}");
             session.Execute($"USE lwt_test");
             session.Execute("CREATE TABLE foo (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
 
@@ -125,7 +125,7 @@ namespace Cassandra.IntegrationTests
 
             // Create keyspace and table
             session.Execute("DROP KEYSPACE IF EXISTS lwt_test");
-            session.Execute($"CREATE KEYSPACE lwt_test WITH replication = {{'class': 'SimpleStrategy', 'replication_factor': 3}}");
+            session.Execute($"CREATE KEYSPACE lwt_test WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 3}}");
             session.Execute($"USE lwt_test");
             session.Execute("CREATE TABLE foo (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
 

--- a/src/Cassandra.IntegrationTests/ShardAwarenessTests.cs
+++ b/src/Cassandra.IntegrationTests/ShardAwarenessTests.cs
@@ -26,7 +26,7 @@ namespace Cassandra.IntegrationTests
         [Test]
         public void CorrectShardInTracingTest()
         {
-            _realCluster = TestClusterManager.CreateNew();
+            _realCluster = TestClusterManager.CreateNew(1);
             var cluster = ClusterBuilder()
                           .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(22000).SetConnectTimeoutMillis(60000))
                           .AddContactPoint(_realCluster.InitialContactPoint)
@@ -34,7 +34,7 @@ namespace Cassandra.IntegrationTests
             var _session = cluster.Connect();
 
             _session.Execute("DROP KEYSPACE IF EXISTS shardawaretest");
-            _session.Execute("CREATE KEYSPACE shardawaretest WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}");
+            _session.Execute("CREATE KEYSPACE shardawaretest WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'} AND tablets = {'enabled': false}");
             _session.Execute("CREATE TABLE shardawaretest.t (pk text, ck text, v text, PRIMARY KEY (pk, ck))");
 
             var populateStatement = _session.Prepare("INSERT INTO shardawaretest.t (pk, ck, v) VALUES (?, ?, ?)");

--- a/src/Cassandra.IntegrationTests/TestBase/TestUtils.cs
+++ b/src/Cassandra.IntegrationTests/TestBase/TestUtils.cs
@@ -40,7 +40,7 @@ namespace Cassandra.IntegrationTests.TestBase
         private const int DefaultSleepIterationMs = 1000;
 
         public static readonly string CreateKeyspaceSimpleFormat =
-            "CREATE KEYSPACE \"{0}\" WITH replication = {{ 'class' : 'SimpleStrategy', 'replication_factor' : {1} }}";
+            "CREATE KEYSPACE \"{0}\" WITH replication = {{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : {1} }} AND tablets = {{'enabled': false}}";
 
         public static readonly string CreateKeyspaceGenericFormat = "CREATE KEYSPACE {0} WITH replication = {{ 'class' : '{1}', {2} }}";
 

--- a/src/Cassandra.IntegrationTests/TestBase/TestUtils.cs
+++ b/src/Cassandra.IntegrationTests/TestBase/TestUtils.cs
@@ -40,7 +40,8 @@ namespace Cassandra.IntegrationTests.TestBase
         private const int DefaultSleepIterationMs = 1000;
 
         public static readonly string CreateKeyspaceSimpleFormat =
-            "CREATE KEYSPACE \"{0}\" WITH replication = {{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : {1} }} AND tablets = {{'enabled': false}}";
+            "CREATE KEYSPACE \"{0}\" WITH replication = {{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : {1} }}" +
+            (TestClusterManager.IsScylla ? " AND tablets = {{'enabled': false}}" : "");
 
         public static readonly string CreateKeyspaceGenericFormat = "CREATE KEYSPACE {0} WITH replication = {{ 'class' : '{1}', {2} }}";
 


### PR DESCRIPTION
With tablets enabled by default in Scylla, SimpleStrategy causes issues. Replace SimpleStrategy with NetworkTopologyStrategy using 'datacenter1' in all integration tests. Where tablets must be disabled (token-aware routing tests, LWT tests, tests using CreateKeyspaceSimpleFormat), add AND tablets = {'enabled': false}.