### PR TITLE
chore: update OpenTelemetry packages to 1.15.3

### DIFF
--- a/examples/OpenTelemetry/DistributedTracing/Api/Api.csproj
+++ b/examples/OpenTelemetry/DistributedTracing/Api/Api.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.7.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>

--- a/examples/OpenTelemetry/DistributedTracing/Client/Client.csproj
+++ b/examples/OpenTelemetry/DistributedTracing/Client/Client.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
   </ItemGroup>
 
 </Project>

--- a/examples/OpenTelemetry/Exporter/ConsoleExporter/ConsoleExporter.csproj
+++ b/examples/OpenTelemetry/Exporter/ConsoleExporter/ConsoleExporter.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.8.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
+++ b/src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj
@@ -34,7 +34,7 @@
 
   <ItemGroup>
     <PackageReference Include="App.Metrics" Version="3.2.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.13.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.15.3" />
     <PackageReference Include="SSH.NET" Version="2025.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />

--- a/src/Extensions/Cassandra.OpenTelemetry/Cassandra.OpenTelemetry.csproj
+++ b/src/Extensions/Cassandra.OpenTelemetry/Cassandra.OpenTelemetry.csproj
@@ -23,8 +23,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.13" />
-    <PackageReference Include="OpenTelemetry.Api" Version="1.13.1" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.0" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Update OpenTelemetry.Api, exporters, and hosting packages to 1.15.3
- Update System.Diagnostics.DiagnosticSource to 10.0.0, required by OpenTelemetry.Api 1.15.3
- Keep OpenTelemetry.Instrumentation.AspNetCore at 1.9.0 because 1.15.3 is not published on NuGet

## Testing
- dotnet restore src/Extensions/Cassandra.OpenTelemetry/Cassandra.OpenTelemetry.csproj --force-evaluate
- dotnet restore src/Cassandra.sln
- dotnet restore examples/examples.sln
