### PR TITLE
Route SELECT at SERIAL/LOCAL_SERIAL consistency like LWT

### DIFF
--- a/src/Cassandra.IntegrationTests/ScyllaLwtTests.cs
+++ b/src/Cassandra.IntegrationTests/ScyllaLwtTests.cs
@@ -12,6 +12,9 @@ namespace Cassandra.IntegrationTests
     [TestFixture]
     public class ScyllaLwtTest : TestGlobals
     {
+        private const int Pk = 1234;
+        private static readonly byte[] PkBytes = { 0, 0, 0x04, 0xd2 }; // pk=1234 as big-endian int
+
         private ITestCluster _realCluster;
 
         [TearDown]
@@ -20,6 +23,52 @@ namespace Cassandra.IntegrationTests
             TestClusterManager.TryRemove();
             _realCluster = null;
         }
+
+        private void Execute(ISession session, string cql, bool useExplicitCl)
+        {
+            var statement = new SimpleStatement(cql);
+            if (useExplicitCl)
+                statement.SetConsistencyLevel(ConsistencyLevel.All);
+            session.Execute(statement);
+        }
+
+        private void SetupKeyspaceAndTable(ISession session, bool useExplicitCl = false)
+        {
+            Execute(session, "DROP KEYSPACE IF EXISTS lwt_test", useExplicitCl);
+            Execute(session, $"CREATE KEYSPACE lwt_test WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 3}}", useExplicitCl);
+            Execute(session, "USE lwt_test", useExplicitCl);
+            Execute(session, "CREATE TABLE foo (pk int, ck int, v int, PRIMARY KEY (pk, ck))", useExplicitCl);
+        }
+
+        private void InsertTestData(ISession session, bool useExplicitCl = false)
+        {
+            for (int i = 0; i < 10; i++)
+                Execute(session, $"INSERT INTO foo (pk, ck, v) VALUES ({Pk}, {i}, {i})", useExplicitCl);
+        }
+
+        private Host GetReplicaOwner(ICluster cluster)
+        {
+            var routingKey = new RoutingKey();
+            routingKey.RawRoutingKey = PkBytes;
+            var replicas = cluster.GetReplicas("lwt_test", routingKey.RawRoutingKey);
+            return replicas.First().Host;
+        }
+
+        private void AssertAllQueriesRouteToSameOwner(ICluster cluster, Func<int, RowSet> executeQuery, string description)
+        {
+            var owner = GetReplicaOwner(cluster);
+            var coordinatorEndpoints = new HashSet<System.Net.IPEndPoint>();
+            for (int i = 0; i < 30; i++)
+            {
+                var result = executeQuery(i);
+                coordinatorEndpoints.Add(result.Info.QueriedHost);
+            }
+
+            Assert.AreEqual(1, coordinatorEndpoints.Count, $"{description} should use only one coordinator");
+            Assert.That(coordinatorEndpoints.Contains(owner.Address), $"{description} should use the replica owner as coordinator");
+        }
+
+
 
         [Test]
         public void Scylla_Should_Recognize_Bound_LWT_Query()
@@ -35,15 +84,12 @@ namespace Cassandra.IntegrationTests
             _session.Execute($"CREATE KEYSPACE lwt_test WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}}");
             _session.Execute("CREATE TABLE IF NOT EXISTS lwt_test.bound_statement_test (a int PRIMARY KEY, b int)");
 
-            // Prepare a non-LWT statement
             var statementNonLWT = _session.Prepare("UPDATE lwt_test.bound_statement_test SET b = ? WHERE a = ?");
-            // Prepare an LWT statement
             var statementLWT = _session.Prepare("UPDATE lwt_test.bound_statement_test SET b = ? WHERE a = ? IF b = ?");
 
             var boundNonLWT = statementNonLWT.Bind(3, 1);
             var boundLWT = statementLWT.Bind(3, 1, 5);
 
-            // Check LWT detection
             Assert.False(boundNonLWT.IsLwt(), "Non-LWT statement should not be detected as LWT");
             Assert.True(boundLWT.IsLwt(), "LWT statement should be detected as LWT");
         }
@@ -62,110 +108,30 @@ namespace Cassandra.IntegrationTests
             _session.Execute($"CREATE KEYSPACE lwt_test WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}}");
             _session.Execute("CREATE TABLE IF NOT EXISTS lwt_test.prepared_statement_test (a int PRIMARY KEY, b int)");
 
-            // Prepare a non-LWT statement
             var statementNonLWT = _session.Prepare("UPDATE lwt_test.prepared_statement_test SET b = 3 WHERE a = 1");
-            // Prepare an LWT statement
             var statementLWT = _session.Prepare("UPDATE lwt_test.prepared_statement_test SET b = 3 WHERE a = 1 IF b = 5");
 
-            // Check LWT detection
             Assert.False(statementNonLWT.IsLwt, "Non-LWT statement should not be detected as LWT");
             Assert.True(statementLWT.IsLwt, "LWT statement should be detected as LWT");
-        }
-
-        [Test, TestScyllaVersion(2026, 1)]
-        public void Should_Use_Only_One_Node_When_LWT_Detected()
-        {
-            _realCluster = TestClusterManager.CreateNew(3);
-            var cluster = ClusterBuilder()
-                          .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(22000).SetConnectTimeoutMillis(60000))
-                          .AddContactPoint(_realCluster.InitialContactPoint)
-                          .Build();
-            var session = cluster.Connect();
-
-            // Create keyspace and table
-            session.Execute("DROP KEYSPACE IF EXISTS lwt_test");
-            session.Execute($"CREATE KEYSPACE lwt_test WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 3}}");
-            session.Execute($"USE lwt_test");
-            session.Execute("CREATE TABLE foo (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
-
-            int pk = 1234;
-            var routingKey = new RoutingKey();
-            routingKey.RawRoutingKey = new byte[] { 0, 0, 0x04, 0xd2 }; // pk=1234 as bytes
-
-            // Get the replicas for this routing key
-            var replicas = cluster.GetReplicas("lwt_test", routingKey.RawRoutingKey);
-            var owner = replicas.First();
-
-            var statement = session.Prepare("INSERT INTO foo (pk, ck, v) VALUES (?, ?, ?) IF NOT EXISTS");
-            Assert.True(statement.IsLwt, "Statement should be detected as LWT");
-
-            var coordinatorEndpoints = new HashSet<System.Net.IPEndPoint>();
-            for (int i = 0; i < 30; i++)
-            {
-                var result = session.Execute(statement.Bind(pk, i, 123));
-                var coordinatorEndpoint = result.Info.QueriedHost;
-                coordinatorEndpoints.Add(coordinatorEndpoint);
-            }
-
-            // For LWT queries, all should go to the same coordinator (the owner)
-            Assert.AreEqual(1, coordinatorEndpoints.Count, "LWT queries should use only one coordinator");
-            Assert.That(coordinatorEndpoints.Contains(owner.Host.Address), "LWT queries should use the replica owner as coordinator");
-        }
-
-        [Test]
-        public void Should_Not_Use_Only_One_Node_When_Non_LWT()
-        {
-            // Sanity check for the previous test - non-LWT queries should not always be sent to same node
-            _realCluster = TestClusterManager.CreateNew(3);
-            var cluster = ClusterBuilder()
-                          .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(22000).SetConnectTimeoutMillis(60000))
-                          .AddContactPoint(_realCluster.InitialContactPoint)
-                          .Build();
-            var session = cluster.Connect();
-
-            // Create keyspace and table
-            session.Execute("DROP KEYSPACE IF EXISTS lwt_test");
-            session.Execute($"CREATE KEYSPACE lwt_test WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 3}}");
-            session.Execute($"USE lwt_test");
-            session.Execute("CREATE TABLE foo (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
-
-            int pk = 1234;
-            var statement = session.Prepare("INSERT INTO foo (pk, ck, v) VALUES (?, ?, ?)");
-            Assert.False(statement.IsLwt, "Statement should not be detected as LWT");
-
-            var coordinatorEndpoints = new HashSet<System.Net.IPEndPoint>();
-            for (int i = 0; i < 30; i++)
-            {
-                var result = session.Execute(statement.Bind(pk, i, 123));
-                var coordinatorEndpoint = result.Info.QueriedHost;
-                coordinatorEndpoints.Add(coordinatorEndpoint);
-            }
-
-            // Because keyspace RF == 3, non-LWT queries should distribute across all nodes
-            Assert.AreEqual(3, coordinatorEndpoints.Count, "Non-LWT queries should use all available coordinators");
         }
 
         [Test]
         public void Scylla_Should_Override_Prepared_LWT_Query()
         {
-            _realCluster = TestClusterManager.CreateNew();
+            _realCluster = TestClusterManager.CreateNew(1);
             var cluster = ClusterBuilder()
-                          .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(22000).SetConnectTimeoutMillis(60000))
-                          .AddContactPoint(_realCluster.InitialContactPoint)
-                          .Build();
-            var _session = cluster.Connect();
+                .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(22000).SetConnectTimeoutMillis(60000))
+                .AddContactPoint(_realCluster.InitialContactPoint)
+                .Build();
+            var session = cluster.Connect();
 
-            _session.Execute("DROP KEYSPACE IF EXISTS lwt_test");
-            _session.Execute($"CREATE KEYSPACE lwt_test WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}}");
-            _session.Execute("CREATE TABLE IF NOT EXISTS lwt_test.prepared_statement_test (a int PRIMARY KEY, b int)");
+            session.Execute("DROP KEYSPACE IF EXISTS lwt_test");
+            session.Execute($"CREATE KEYSPACE lwt_test WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}}");
+            session.Execute("CREATE TABLE IF NOT EXISTS lwt_test.prepared_statement_test (a int PRIMARY KEY, b int)");
 
-            // Prepare a non-LWT statement, but override it
-            var statementNonLWT = _session.Prepare("UPDATE lwt_test.prepared_statement_test SET b = 3 WHERE a = 1").SetLwt(true);
+            var statementNonLWT = session.Prepare("UPDATE lwt_test.prepared_statement_test SET b = 3 WHERE a = 1").SetLwt(true);
+            var statementLWT = session.Prepare("UPDATE lwt_test.prepared_statement_test SET b = 3 WHERE a = 1 IF b = 5").SetLwt(false);
 
-            // Prepare an LWT statement, but override it
-            var statementLWT = _session.Prepare("UPDATE lwt_test.prepared_statement_test SET b = 3 WHERE a = 1 IF b = 5").SetLwt(false);
-
-            // Check LWT detection
             Assert.True(statementNonLWT.IsLwt, "Overridden non-LWT statement should be detected as LWT");
             Assert.False(statementLWT.IsLwt, "Overridden LWT statement should not be detected as LWT");
         }
@@ -173,28 +139,262 @@ namespace Cassandra.IntegrationTests
         [Test]
         public void Scylla_Should_Override_Bound_LWT_Query()
         {
-            _realCluster = TestClusterManager.CreateNew();
+            _realCluster = TestClusterManager.CreateNew(1);
             var cluster = ClusterBuilder()
-                          .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(22000).SetConnectTimeoutMillis(60000))
-                          .AddContactPoint(_realCluster.InitialContactPoint)
-                          .Build();
-            var _session = cluster.Connect();
+                .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(22000).SetConnectTimeoutMillis(60000))
+                .AddContactPoint(_realCluster.InitialContactPoint)
+                .Build();
+            var session = cluster.Connect();
 
-            _session.Execute("DROP KEYSPACE IF EXISTS lwt_test");
-            _session.Execute($"CREATE KEYSPACE lwt_test WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}}");
-            _session.Execute("CREATE TABLE IF NOT EXISTS lwt_test.bound_statement_test (a int PRIMARY KEY, b int)");
+            session.Execute("DROP KEYSPACE IF EXISTS lwt_test");
+            session.Execute($"CREATE KEYSPACE lwt_test WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}}");
+            session.Execute("CREATE TABLE IF NOT EXISTS lwt_test.bound_statement_test (a int PRIMARY KEY, b int)");
 
-            var statementNonLWT = _session.Prepare("UPDATE lwt_test.bound_statement_test SET b = ? WHERE a = ?");
-            var statementLWT = _session.Prepare("UPDATE lwt_test.bound_statement_test SET b = ? WHERE a = ? IF b = ?");
+            var statementNonLWT = session.Prepare("UPDATE lwt_test.bound_statement_test SET b = ? WHERE a = ?");
+            var statementLWT = session.Prepare("UPDATE lwt_test.bound_statement_test SET b = ? WHERE a = ? IF b = ?");
 
-            // Bind the non-LWT statement but override it to be LWT
             var boundNonLWT = statementNonLWT.Bind(3, 1).SetLwt(true);
-            // Bind the LWT statement but override it to be non-LWT
             var boundLWT = statementLWT.Bind(3, 1, 5).SetLwt(false);
 
             Assert.True(boundNonLWT.IsLwt(), "Override Non-LWT statement should be detected as LWT");
             Assert.False(boundLWT.IsLwt(), "Override LWT statement should not be detected as LWT");
         }
+
+
+
+        [Test, TestScyllaVersion(2026, 1)]
+        public void Should_Use_Only_One_Node_When_LWT_Detected()
+        {
+            _realCluster = TestClusterManager.CreateNew(3);
+            var cluster = ClusterBuilder()
+                .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(22000).SetConnectTimeoutMillis(60000))
+                .AddContactPoint(_realCluster.InitialContactPoint)
+                .Build();
+            var session = cluster.Connect();
+            SetupKeyspaceAndTable(session);
+
+            var statement = session.Prepare("INSERT INTO foo (pk, ck, v) VALUES (?, ?, ?) IF NOT EXISTS");
+            Assert.True(statement.IsLwt, "Statement should be detected as LWT");
+
+            AssertAllQueriesRouteToSameOwner(cluster,
+                i => session.Execute(statement.Bind(Pk, i, 123)),
+                "LWT queries");
+        }
+
+        [Test]
+        public void Should_Not_Use_Only_One_Node_When_Non_LWT()
+        {
+            _realCluster = TestClusterManager.CreateNew(3);
+            var cluster = ClusterBuilder()
+                .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(22000).SetConnectTimeoutMillis(60000))
+                .AddContactPoint(_realCluster.InitialContactPoint)
+                .Build();
+            var session = cluster.Connect();
+            SetupKeyspaceAndTable(session);
+
+            var statement = session.Prepare("INSERT INTO foo (pk, ck, v) VALUES (?, ?, ?)");
+            Assert.False(statement.IsLwt, "Statement should not be detected as LWT");
+
+            var coordinatorEndpoints = new HashSet<System.Net.IPEndPoint>();
+            for (int i = 0; i < 30; i++)
+            {
+                var result = session.Execute(statement.Bind(Pk, i, 123));
+                coordinatorEndpoints.Add(result.Info.QueriedHost);
+            }
+
+            Assert.AreEqual(3, coordinatorEndpoints.Count, "Non-LWT queries should use all available coordinators");
+        }
+
+        [Test, TestScyllaVersion(2026, 1)]
+        public void Should_Use_Only_One_Node_When_Select_With_Serial_Consistency()
+        {
+            _realCluster = TestClusterManager.CreateNew(3);
+            var cluster = ClusterBuilder()
+                .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(22000).SetConnectTimeoutMillis(60000))
+                .AddContactPoint(_realCluster.InitialContactPoint)
+                .Build();
+            var _session = cluster.Connect();
+            SetupKeyspaceAndTable(session);
+            InsertTestData(session);
+
+            var statement = session.Prepare("SELECT v FROM foo WHERE pk = ?");
+            Assert.False(statement.IsLwt, "SELECT statement should not be marked as LWT by server");
+
+            AssertAllQueriesRouteToSameOwner(cluster, i =>
+            {
+                var bound = statement.Bind(Pk);
+                bound.SetConsistencyLevel(ConsistencyLevel.Serial);
+                Assert.True(bound.ShouldRouteAsLwt(), "BoundStatement with Serial consistency should be routed as LWT");
+                return session.Execute(bound);
+            }, "Serial SELECT queries");
+        }
+
+        [Test, TestScyllaVersion(2026, 1)]
+        public void Should_Use_Only_One_Node_When_Select_With_LocalSerial_Consistency()
+        {
+            _realCluster = TestClusterManager.CreateNew(3);
+            var cluster = ClusterBuilder()
+                .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(22000).SetConnectTimeoutMillis(60000))
+                .AddContactPoint(_realCluster.InitialContactPoint)
+                .Build();
+            var session = cluster.Connect();
+            SetupKeyspaceAndTable(session);
+            InsertTestData(session);
+
+            var statement = session.Prepare("SELECT v FROM foo WHERE pk = ?");
+
+            AssertAllQueriesRouteToSameOwner(cluster, i =>
+            {
+                var bound = statement.Bind(Pk);
+                bound.SetConsistencyLevel(ConsistencyLevel.LocalSerial);
+                Assert.True(bound.ShouldRouteAsLwt(), "BoundStatement with LocalSerial consistency should be routed as LWT");
+                return session.Execute(bound);
+            }, "LocalSerial SELECT queries");
+        }
+
+        [Test, TestScyllaVersion(2026, 1)]
+        public void Should_Use_Only_One_Node_When_SimpleStatement_With_Serial_Consistency()
+        {
+            _realCluster = TestClusterManager.CreateNew(3);
+            var cluster = ClusterBuilder()
+                .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(22000).SetConnectTimeoutMillis(60000))
+                .AddContactPoint(_realCluster.InitialContactPoint)
+                .Build();
+            var session = cluster.Connect();
+            SetupKeyspaceAndTable(session);
+            InsertTestData(session);
+
+            AssertAllQueriesRouteToSameOwner(cluster, i =>
+            {
+                var stmt = new SimpleStatement("SELECT v FROM foo WHERE pk = 1234");
+                stmt.SetConsistencyLevel(ConsistencyLevel.Serial);
+                stmt.SetRoutingValues(Pk);
+                Assert.True(stmt.ShouldRouteAsLwt(), "SimpleStatement with Serial consistency should be routed as LWT");
+                return session.Execute(stmt);
+            }, "Serial SimpleStatement queries");
+        }
+
+        [Test, TestScyllaVersion(2026, 1)]
+        public void Should_Use_Only_One_Node_When_Select_With_Serial_Consistency_From_RequestOptions()
+        {
+            _realCluster = TestClusterManager.CreateNew(3);
+            var cluster = ClusterBuilder()
+                .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(22000).SetConnectTimeoutMillis(60000))
+                .AddContactPoint(_realCluster.InitialContactPoint)
+                .WithQueryOptions(new QueryOptions().SetConsistencyLevel(ConsistencyLevel.Serial))
+                .Build();
+            var session = cluster.Connect();
+            SetupKeyspaceAndTable(session, useExplicitCl: true);
+            InsertTestData(session, useExplicitCl: true);
+
+            var statement = session.Prepare("SELECT v FROM foo WHERE pk = ?");
+            Assert.False(statement.IsLwt, "SELECT statement should not be marked as LWT by server");
+
+            AssertAllQueriesRouteToSameOwner(cluster, i =>
+            {
+                var bound = statement.Bind(Pk);
+                Assert.False(bound.ShouldRouteAsLwt(), "BoundStatement without explicit CL should not report ShouldRouteAsLwt");
+                return session.Execute(bound);
+            }, "Serial SELECT queries (via request options)");
+        }
+
+        [Test, TestScyllaVersion(2026, 1)]
+        public void Should_Use_Only_One_Node_When_Select_With_LocalSerial_Consistency_From_RequestOptions()
+        {
+            _realCluster = TestClusterManager.CreateNew(3);
+            var cluster = ClusterBuilder()
+                .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(22000).SetConnectTimeoutMillis(60000))
+                .AddContactPoint(_realCluster.InitialContactPoint)
+                .WithQueryOptions(new QueryOptions().SetConsistencyLevel(ConsistencyLevel.LocalSerial))
+                .Build();
+            var session = cluster.Connect();
+            SetupKeyspaceAndTable(session, useExplicitCl: true);
+            InsertTestData(session, useExplicitCl: true);
+
+            var statement = session.Prepare("SELECT v FROM foo WHERE pk = ?");
+
+            AssertAllQueriesRouteToSameOwner(cluster, i =>
+            {
+                var bound = statement.Bind(Pk);
+                Assert.False(bound.ShouldRouteAsLwt(), "BoundStatement without explicit CL should not report ShouldRouteAsLwt");
+                return session.Execute(bound);
+            }, "LocalSerial SELECT queries (via request options)");
+        }
+
+        [Test, TestScyllaVersion(2026, 1)]
+        public void Should_Use_Only_One_Node_When_Select_With_Serial_Consistency_From_ExecutionProfile()
+        {
+            _realCluster = TestClusterManager.CreateNew(3);
+            var cluster = ClusterBuilder()
+                .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(22000).SetConnectTimeoutMillis(60000))
+                .AddContactPoint(_realCluster.InitialContactPoint)
+                .WithExecutionProfiles(opts => opts
+                    .WithProfile("serial", profile => profile
+                        .WithConsistencyLevel(ConsistencyLevel.Serial)))
+                .Build();
+            var session = cluster.Connect();
+            SetupKeyspaceAndTable(session);
+            InsertTestData(session);
+
+            var statement = session.Prepare("SELECT v FROM foo WHERE pk = ?");
+            Assert.False(statement.IsLwt, "SELECT statement should not be marked as LWT by server");
+
+            AssertAllQueriesRouteToSameOwner(cluster, i =>
+            {
+                var bound = statement.Bind(Pk);
+                Assert.False(bound.ShouldRouteAsLwt(), "BoundStatement without explicit CL should not report ShouldRouteAsLwt");
+                return session.Execute(bound, "serial");
+            }, "Serial SELECT queries (via execution profile)");
+        }
+
+        [Test, TestScyllaVersion(2026, 1)]
+        public void Should_Use_Only_One_Node_When_Select_With_LocalSerial_Consistency_From_ExecutionProfile()
+        {
+            _realCluster = TestClusterManager.CreateNew(3);
+            var cluster = ClusterBuilder()
+                .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(22000).SetConnectTimeoutMillis(60000))
+                .AddContactPoint(_realCluster.InitialContactPoint)
+                .WithExecutionProfiles(opts => opts
+                    .WithProfile("local_serial", profile => profile
+                        .WithConsistencyLevel(ConsistencyLevel.LocalSerial)))
+                .Build();
+            var session = cluster.Connect();
+            SetupKeyspaceAndTable(session);
+            InsertTestData(session);
+
+            var statement = session.Prepare("SELECT v FROM foo WHERE pk = ?");
+            Assert.False(statement.IsLwt, "SELECT statement should not be marked as LWT by server");
+
+            AssertAllQueriesRouteToSameOwner(cluster, i =>
+            {
+                var bound = statement.Bind(Pk);
+                Assert.False(bound.ShouldRouteAsLwt(), "BoundStatement without explicit CL should not report ShouldRouteAsLwt");
+                return session.Execute(bound, "local_serial");
+            }, "LocalSerial SELECT queries (via execution profile)");
+        }
+
+        [Test, TestScyllaVersion(2026, 1)]
+        public void Should_Use_Only_One_Node_When_SimpleStatement_With_Serial_Consistency_From_RequestOptions()
+        {
+            _realCluster = TestClusterManager.CreateNew(3);
+            var cluster = ClusterBuilder()
+                .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(22000).SetConnectTimeoutMillis(60000))
+                .AddContactPoint(_realCluster.InitialContactPoint)
+                .WithQueryOptions(new QueryOptions().SetConsistencyLevel(ConsistencyLevel.Serial))
+                .Build();
+            var session = cluster.Connect();
+            SetupKeyspaceAndTable(session, useExplicitCl: true);
+            InsertTestData(session, useExplicitCl: true);
+
+            AssertAllQueriesRouteToSameOwner(cluster, i =>
+            {
+                var stmt = new SimpleStatement("SELECT v FROM foo WHERE pk = 1234");
+                stmt.SetRoutingValues(Pk);
+                Assert.False(stmt.ShouldRouteAsLwt(), "SimpleStatement without explicit CL should not report ShouldRouteAsLwt");
+                return session.Execute(stmt);
+            }, "Serial SimpleStatement queries (via request options)");
+        }
+
     }
 
 }

--- a/src/Cassandra.IntegrationTests/ScyllaLwtTests.cs
+++ b/src/Cassandra.IntegrationTests/ScyllaLwtTests.cs
@@ -16,12 +16,33 @@ namespace Cassandra.IntegrationTests
         private static readonly byte[] PkBytes = { 0, 0, 0x04, 0xd2 }; // pk=1234 as big-endian int
 
         private ITestCluster _realCluster;
+        private ICluster _cluster;
 
         [TearDown]
         public void TestTearDown()
         {
+            _cluster?.Shutdown();
+            _cluster = null;
             TestClusterManager.TryRemove();
             _realCluster = null;
+        }
+
+        private ISession CreateClusterAndSession(int nodeCount = 3, QueryOptions queryOptions = null,
+            Action<IExecutionProfileOptions> executionProfiles = null)
+        {
+            _realCluster = TestClusterManager.CreateNew(nodeCount);
+            var builder = ClusterBuilder()
+                .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(22000).SetConnectTimeoutMillis(60000))
+                .AddContactPoint(_realCluster.InitialContactPoint);
+
+            if (queryOptions != null)
+                builder = builder.WithQueryOptions(queryOptions);
+
+            if (executionProfiles != null)
+                builder = builder.WithExecutionProfiles(executionProfiles);
+
+            _cluster = builder.Build();
+            return _cluster.Connect();
         }
 
         private void Execute(ISession session, string cql, bool useExplicitCl)
@@ -46,17 +67,17 @@ namespace Cassandra.IntegrationTests
                 Execute(session, $"INSERT INTO foo (pk, ck, v) VALUES ({Pk}, {i}, {i})", useExplicitCl);
         }
 
-        private Host GetReplicaOwner(ICluster cluster)
+        private Host GetReplicaOwner()
         {
             var routingKey = new RoutingKey();
             routingKey.RawRoutingKey = PkBytes;
-            var replicas = cluster.GetReplicas("lwt_test", routingKey.RawRoutingKey);
+            var replicas = _cluster.GetReplicas("lwt_test", routingKey.RawRoutingKey);
             return replicas.First().Host;
         }
 
-        private void AssertAllQueriesRouteToSameOwner(ICluster cluster, Func<int, RowSet> executeQuery, string description)
+        private void AssertAllQueriesRouteToSameOwner(Func<int, RowSet> executeQuery, string description)
         {
-            var owner = GetReplicaOwner(cluster);
+            var owner = GetReplicaOwner();
             var coordinatorEndpoints = new HashSet<System.Net.IPEndPoint>();
             for (int i = 0; i < 30; i++)
             {
@@ -73,19 +94,14 @@ namespace Cassandra.IntegrationTests
         [Test]
         public void Scylla_Should_Recognize_Bound_LWT_Query()
         {
-            _realCluster = TestClusterManager.CreateNew();
-            var cluster = ClusterBuilder()
-                          .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(22000).SetConnectTimeoutMillis(60000))
-                          .AddContactPoint(_realCluster.InitialContactPoint)
-                          .Build();
-            var _session = cluster.Connect();
+            var session = CreateClusterAndSession(nodeCount: 1);
 
-            _session.Execute("DROP KEYSPACE IF EXISTS lwt_test");
-            _session.Execute($"CREATE KEYSPACE lwt_test WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}}");
-            _session.Execute("CREATE TABLE IF NOT EXISTS lwt_test.bound_statement_test (a int PRIMARY KEY, b int)");
+            session.Execute("DROP KEYSPACE IF EXISTS lwt_test");
+            session.Execute($"CREATE KEYSPACE lwt_test WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}}");
+            session.Execute("CREATE TABLE IF NOT EXISTS lwt_test.bound_statement_test (a int PRIMARY KEY, b int)");
 
-            var statementNonLWT = _session.Prepare("UPDATE lwt_test.bound_statement_test SET b = ? WHERE a = ?");
-            var statementLWT = _session.Prepare("UPDATE lwt_test.bound_statement_test SET b = ? WHERE a = ? IF b = ?");
+            var statementNonLWT = session.Prepare("UPDATE lwt_test.bound_statement_test SET b = ? WHERE a = ?");
+            var statementLWT = session.Prepare("UPDATE lwt_test.bound_statement_test SET b = ? WHERE a = ? IF b = ?");
 
             var boundNonLWT = statementNonLWT.Bind(3, 1);
             var boundLWT = statementLWT.Bind(3, 1, 5);
@@ -97,19 +113,14 @@ namespace Cassandra.IntegrationTests
         [Test]
         public void Scylla_Should_Recognize_Prepared_LWT_Query()
         {
-            _realCluster = TestClusterManager.CreateNew();
-            var cluster = ClusterBuilder()
-                          .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(22000).SetConnectTimeoutMillis(60000))
-                          .AddContactPoint(_realCluster.InitialContactPoint)
-                          .Build();
-            var _session = cluster.Connect();
+            var session = CreateClusterAndSession(nodeCount: 1);
 
-            _session.Execute("DROP KEYSPACE IF EXISTS lwt_test");
-            _session.Execute($"CREATE KEYSPACE lwt_test WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}}");
-            _session.Execute("CREATE TABLE IF NOT EXISTS lwt_test.prepared_statement_test (a int PRIMARY KEY, b int)");
+            session.Execute("DROP KEYSPACE IF EXISTS lwt_test");
+            session.Execute($"CREATE KEYSPACE lwt_test WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}}");
+            session.Execute("CREATE TABLE IF NOT EXISTS lwt_test.prepared_statement_test (a int PRIMARY KEY, b int)");
 
-            var statementNonLWT = _session.Prepare("UPDATE lwt_test.prepared_statement_test SET b = 3 WHERE a = 1");
-            var statementLWT = _session.Prepare("UPDATE lwt_test.prepared_statement_test SET b = 3 WHERE a = 1 IF b = 5");
+            var statementNonLWT = session.Prepare("UPDATE lwt_test.prepared_statement_test SET b = 3 WHERE a = 1");
+            var statementLWT = session.Prepare("UPDATE lwt_test.prepared_statement_test SET b = 3 WHERE a = 1 IF b = 5");
 
             Assert.False(statementNonLWT.IsLwt, "Non-LWT statement should not be detected as LWT");
             Assert.True(statementLWT.IsLwt, "LWT statement should be detected as LWT");
@@ -118,12 +129,7 @@ namespace Cassandra.IntegrationTests
         [Test]
         public void Scylla_Should_Override_Prepared_LWT_Query()
         {
-            _realCluster = TestClusterManager.CreateNew(1);
-            var cluster = ClusterBuilder()
-                .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(22000).SetConnectTimeoutMillis(60000))
-                .AddContactPoint(_realCluster.InitialContactPoint)
-                .Build();
-            var session = cluster.Connect();
+            var session = CreateClusterAndSession(nodeCount: 1);
 
             session.Execute("DROP KEYSPACE IF EXISTS lwt_test");
             session.Execute($"CREATE KEYSPACE lwt_test WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}}");
@@ -139,12 +145,7 @@ namespace Cassandra.IntegrationTests
         [Test]
         public void Scylla_Should_Override_Bound_LWT_Query()
         {
-            _realCluster = TestClusterManager.CreateNew(1);
-            var cluster = ClusterBuilder()
-                .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(22000).SetConnectTimeoutMillis(60000))
-                .AddContactPoint(_realCluster.InitialContactPoint)
-                .Build();
-            var session = cluster.Connect();
+            var session = CreateClusterAndSession(nodeCount: 1);
 
             session.Execute("DROP KEYSPACE IF EXISTS lwt_test");
             session.Execute($"CREATE KEYSPACE lwt_test WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}}");
@@ -165,18 +166,13 @@ namespace Cassandra.IntegrationTests
         [Test, TestScyllaVersion(2026, 1)]
         public void Should_Use_Only_One_Node_When_LWT_Detected()
         {
-            _realCluster = TestClusterManager.CreateNew(3);
-            var cluster = ClusterBuilder()
-                .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(22000).SetConnectTimeoutMillis(60000))
-                .AddContactPoint(_realCluster.InitialContactPoint)
-                .Build();
-            var session = cluster.Connect();
+            var session = CreateClusterAndSession();
             SetupKeyspaceAndTable(session);
 
             var statement = session.Prepare("INSERT INTO foo (pk, ck, v) VALUES (?, ?, ?) IF NOT EXISTS");
             Assert.True(statement.IsLwt, "Statement should be detected as LWT");
 
-            AssertAllQueriesRouteToSameOwner(cluster,
+            AssertAllQueriesRouteToSameOwner(
                 i => session.Execute(statement.Bind(Pk, i, 123)),
                 "LWT queries");
         }
@@ -184,12 +180,7 @@ namespace Cassandra.IntegrationTests
         [Test]
         public void Should_Not_Use_Only_One_Node_When_Non_LWT()
         {
-            _realCluster = TestClusterManager.CreateNew(3);
-            var cluster = ClusterBuilder()
-                .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(22000).SetConnectTimeoutMillis(60000))
-                .AddContactPoint(_realCluster.InitialContactPoint)
-                .Build();
-            var session = cluster.Connect();
+            var session = CreateClusterAndSession();
             SetupKeyspaceAndTable(session);
 
             var statement = session.Prepare("INSERT INTO foo (pk, ck, v) VALUES (?, ?, ?)");
@@ -208,19 +199,14 @@ namespace Cassandra.IntegrationTests
         [Test, TestScyllaVersion(2026, 1)]
         public void Should_Use_Only_One_Node_When_Select_With_Serial_Consistency()
         {
-            _realCluster = TestClusterManager.CreateNew(3);
-            var cluster = ClusterBuilder()
-                .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(22000).SetConnectTimeoutMillis(60000))
-                .AddContactPoint(_realCluster.InitialContactPoint)
-                .Build();
-            var _session = cluster.Connect();
+            var session = CreateClusterAndSession();
             SetupKeyspaceAndTable(session);
             InsertTestData(session);
 
             var statement = session.Prepare("SELECT v FROM foo WHERE pk = ?");
             Assert.False(statement.IsLwt, "SELECT statement should not be marked as LWT by server");
 
-            AssertAllQueriesRouteToSameOwner(cluster, i =>
+            AssertAllQueriesRouteToSameOwner(i =>
             {
                 var bound = statement.Bind(Pk);
                 bound.SetConsistencyLevel(ConsistencyLevel.Serial);
@@ -232,18 +218,13 @@ namespace Cassandra.IntegrationTests
         [Test, TestScyllaVersion(2026, 1)]
         public void Should_Use_Only_One_Node_When_Select_With_LocalSerial_Consistency()
         {
-            _realCluster = TestClusterManager.CreateNew(3);
-            var cluster = ClusterBuilder()
-                .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(22000).SetConnectTimeoutMillis(60000))
-                .AddContactPoint(_realCluster.InitialContactPoint)
-                .Build();
-            var session = cluster.Connect();
+            var session = CreateClusterAndSession();
             SetupKeyspaceAndTable(session);
             InsertTestData(session);
 
             var statement = session.Prepare("SELECT v FROM foo WHERE pk = ?");
 
-            AssertAllQueriesRouteToSameOwner(cluster, i =>
+            AssertAllQueriesRouteToSameOwner(i =>
             {
                 var bound = statement.Bind(Pk);
                 bound.SetConsistencyLevel(ConsistencyLevel.LocalSerial);
@@ -255,16 +236,11 @@ namespace Cassandra.IntegrationTests
         [Test, TestScyllaVersion(2026, 1)]
         public void Should_Use_Only_One_Node_When_SimpleStatement_With_Serial_Consistency()
         {
-            _realCluster = TestClusterManager.CreateNew(3);
-            var cluster = ClusterBuilder()
-                .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(22000).SetConnectTimeoutMillis(60000))
-                .AddContactPoint(_realCluster.InitialContactPoint)
-                .Build();
-            var session = cluster.Connect();
+            var session = CreateClusterAndSession();
             SetupKeyspaceAndTable(session);
             InsertTestData(session);
 
-            AssertAllQueriesRouteToSameOwner(cluster, i =>
+            AssertAllQueriesRouteToSameOwner(i =>
             {
                 var stmt = new SimpleStatement("SELECT v FROM foo WHERE pk = 1234");
                 stmt.SetConsistencyLevel(ConsistencyLevel.Serial);
@@ -277,20 +253,15 @@ namespace Cassandra.IntegrationTests
         [Test, TestScyllaVersion(2026, 1)]
         public void Should_Use_Only_One_Node_When_Select_With_Serial_Consistency_From_RequestOptions()
         {
-            _realCluster = TestClusterManager.CreateNew(3);
-            var cluster = ClusterBuilder()
-                .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(22000).SetConnectTimeoutMillis(60000))
-                .AddContactPoint(_realCluster.InitialContactPoint)
-                .WithQueryOptions(new QueryOptions().SetConsistencyLevel(ConsistencyLevel.Serial))
-                .Build();
-            var session = cluster.Connect();
+            var session = CreateClusterAndSession(
+                queryOptions: new QueryOptions().SetConsistencyLevel(ConsistencyLevel.Serial));
             SetupKeyspaceAndTable(session, useExplicitCl: true);
             InsertTestData(session, useExplicitCl: true);
 
             var statement = session.Prepare("SELECT v FROM foo WHERE pk = ?");
             Assert.False(statement.IsLwt, "SELECT statement should not be marked as LWT by server");
 
-            AssertAllQueriesRouteToSameOwner(cluster, i =>
+            AssertAllQueriesRouteToSameOwner(i =>
             {
                 var bound = statement.Bind(Pk);
                 Assert.False(bound.ShouldRouteAsLwt(), "BoundStatement without explicit CL should not report ShouldRouteAsLwt");
@@ -301,19 +272,14 @@ namespace Cassandra.IntegrationTests
         [Test, TestScyllaVersion(2026, 1)]
         public void Should_Use_Only_One_Node_When_Select_With_LocalSerial_Consistency_From_RequestOptions()
         {
-            _realCluster = TestClusterManager.CreateNew(3);
-            var cluster = ClusterBuilder()
-                .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(22000).SetConnectTimeoutMillis(60000))
-                .AddContactPoint(_realCluster.InitialContactPoint)
-                .WithQueryOptions(new QueryOptions().SetConsistencyLevel(ConsistencyLevel.LocalSerial))
-                .Build();
-            var session = cluster.Connect();
+            var session = CreateClusterAndSession(
+                queryOptions: new QueryOptions().SetConsistencyLevel(ConsistencyLevel.LocalSerial));
             SetupKeyspaceAndTable(session, useExplicitCl: true);
             InsertTestData(session, useExplicitCl: true);
 
             var statement = session.Prepare("SELECT v FROM foo WHERE pk = ?");
 
-            AssertAllQueriesRouteToSameOwner(cluster, i =>
+            AssertAllQueriesRouteToSameOwner(i =>
             {
                 var bound = statement.Bind(Pk);
                 Assert.False(bound.ShouldRouteAsLwt(), "BoundStatement without explicit CL should not report ShouldRouteAsLwt");
@@ -324,22 +290,16 @@ namespace Cassandra.IntegrationTests
         [Test, TestScyllaVersion(2026, 1)]
         public void Should_Use_Only_One_Node_When_Select_With_Serial_Consistency_From_ExecutionProfile()
         {
-            _realCluster = TestClusterManager.CreateNew(3);
-            var cluster = ClusterBuilder()
-                .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(22000).SetConnectTimeoutMillis(60000))
-                .AddContactPoint(_realCluster.InitialContactPoint)
-                .WithExecutionProfiles(opts => opts
-                    .WithProfile("serial", profile => profile
-                        .WithConsistencyLevel(ConsistencyLevel.Serial)))
-                .Build();
-            var session = cluster.Connect();
+            var session = CreateClusterAndSession(executionProfiles: opts => opts
+                .WithProfile("serial", profile => profile
+                    .WithConsistencyLevel(ConsistencyLevel.Serial)));
             SetupKeyspaceAndTable(session);
             InsertTestData(session);
 
             var statement = session.Prepare("SELECT v FROM foo WHERE pk = ?");
             Assert.False(statement.IsLwt, "SELECT statement should not be marked as LWT by server");
 
-            AssertAllQueriesRouteToSameOwner(cluster, i =>
+            AssertAllQueriesRouteToSameOwner(i =>
             {
                 var bound = statement.Bind(Pk);
                 Assert.False(bound.ShouldRouteAsLwt(), "BoundStatement without explicit CL should not report ShouldRouteAsLwt");
@@ -350,22 +310,16 @@ namespace Cassandra.IntegrationTests
         [Test, TestScyllaVersion(2026, 1)]
         public void Should_Use_Only_One_Node_When_Select_With_LocalSerial_Consistency_From_ExecutionProfile()
         {
-            _realCluster = TestClusterManager.CreateNew(3);
-            var cluster = ClusterBuilder()
-                .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(22000).SetConnectTimeoutMillis(60000))
-                .AddContactPoint(_realCluster.InitialContactPoint)
-                .WithExecutionProfiles(opts => opts
-                    .WithProfile("local_serial", profile => profile
-                        .WithConsistencyLevel(ConsistencyLevel.LocalSerial)))
-                .Build();
-            var session = cluster.Connect();
+            var session = CreateClusterAndSession(executionProfiles: opts => opts
+                .WithProfile("local_serial", profile => profile
+                    .WithConsistencyLevel(ConsistencyLevel.LocalSerial)));
             SetupKeyspaceAndTable(session);
             InsertTestData(session);
 
             var statement = session.Prepare("SELECT v FROM foo WHERE pk = ?");
             Assert.False(statement.IsLwt, "SELECT statement should not be marked as LWT by server");
 
-            AssertAllQueriesRouteToSameOwner(cluster, i =>
+            AssertAllQueriesRouteToSameOwner(i =>
             {
                 var bound = statement.Bind(Pk);
                 Assert.False(bound.ShouldRouteAsLwt(), "BoundStatement without explicit CL should not report ShouldRouteAsLwt");
@@ -376,17 +330,12 @@ namespace Cassandra.IntegrationTests
         [Test, TestScyllaVersion(2026, 1)]
         public void Should_Use_Only_One_Node_When_SimpleStatement_With_Serial_Consistency_From_RequestOptions()
         {
-            _realCluster = TestClusterManager.CreateNew(3);
-            var cluster = ClusterBuilder()
-                .WithSocketOptions(new SocketOptions().SetReadTimeoutMillis(22000).SetConnectTimeoutMillis(60000))
-                .AddContactPoint(_realCluster.InitialContactPoint)
-                .WithQueryOptions(new QueryOptions().SetConsistencyLevel(ConsistencyLevel.Serial))
-                .Build();
-            var session = cluster.Connect();
+            var session = CreateClusterAndSession(
+                queryOptions: new QueryOptions().SetConsistencyLevel(ConsistencyLevel.Serial));
             SetupKeyspaceAndTable(session, useExplicitCl: true);
             InsertTestData(session, useExplicitCl: true);
 
-            AssertAllQueriesRouteToSameOwner(cluster, i =>
+            AssertAllQueriesRouteToSameOwner(i =>
             {
                 var stmt = new SimpleStatement("SELECT v FROM foo WHERE pk = 1234");
                 stmt.SetRoutingValues(Pk);

--- a/src/Cassandra.Tests/SerialConsistencyLwtTests.cs
+++ b/src/Cassandra.Tests/SerialConsistencyLwtTests.cs
@@ -1,0 +1,264 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cassandra.Requests;
+using Moq;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+#pragma warning disable 618
+
+namespace Cassandra.Tests
+{
+    [TestFixture]
+    public class SerialConsistencyLwtTests
+    {
+        [Test]
+        public void SimpleStatement_With_Serial_Consistency_Should_Be_Lwt()
+        {
+            var statement = new SimpleStatement("SELECT v FROM ks.t WHERE pk = ?");
+            statement.SetConsistencyLevel(ConsistencyLevel.Serial);
+            Assert.False(statement.IsLwt(), "SimpleStatement is never a confirmed LWT");
+            Assert.True(statement.ShouldRouteAsLwt(), "SimpleStatement with Serial consistency should route as LWT");
+        }
+
+        [Test]
+        public void SimpleStatement_With_LocalSerial_Consistency_Should_Be_Lwt()
+        {
+            var statement = new SimpleStatement("SELECT v FROM ks.t WHERE pk = ?");
+            statement.SetConsistencyLevel(ConsistencyLevel.LocalSerial);
+            Assert.False(statement.IsLwt(), "SimpleStatement is never a confirmed LWT");
+            Assert.True(statement.ShouldRouteAsLwt(), "SimpleStatement with LocalSerial consistency should route as LWT");
+        }
+
+        [Test]
+        public void SimpleStatement_Without_Serial_Consistency_Should_Not_Be_Lwt()
+        {
+            var statement = new SimpleStatement("SELECT v FROM ks.t WHERE pk = ?");
+            statement.SetConsistencyLevel(ConsistencyLevel.Quorum);
+            Assert.False(statement.IsLwt(), "SimpleStatement with Quorum consistency should not be detected as LWT");
+            Assert.False(statement.ShouldRouteAsLwt(), "SimpleStatement with Quorum consistency should not route as LWT");
+        }
+
+        [Test]
+        public void SimpleStatement_Without_Consistency_Should_Not_Be_Lwt()
+        {
+            var statement = new SimpleStatement("SELECT v FROM ks.t WHERE pk = ?");
+            Assert.False(statement.IsLwt(), "SimpleStatement without explicit consistency should not be detected as LWT");
+            Assert.False(statement.ShouldRouteAsLwt(), "SimpleStatement without explicit consistency should not route as LWT");
+        }
+
+        [Test]
+        public void BoundStatement_With_Serial_Consistency_Should_Be_Lwt()
+        {
+            var ps = new PreparedStatement();
+            ps.SetLwt(false);
+            var bound = new BoundStatement(ps);
+            bound.SetConsistencyLevel(ConsistencyLevel.Serial);
+            Assert.False(bound.IsLwt(), "BoundStatement without prepared LWT should not be confirmed LWT");
+            Assert.True(bound.ShouldRouteAsLwt(), "BoundStatement with Serial consistency should route as LWT");
+        }
+
+        [Test]
+        public void BoundStatement_With_LocalSerial_Consistency_Should_Be_Lwt()
+        {
+            var ps = new PreparedStatement();
+            ps.SetLwt(false);
+            var bound = new BoundStatement(ps);
+            bound.SetConsistencyLevel(ConsistencyLevel.LocalSerial);
+            Assert.False(bound.IsLwt(), "BoundStatement without prepared LWT should not be confirmed LWT");
+            Assert.True(bound.ShouldRouteAsLwt(), "BoundStatement with LocalSerial consistency should route as LWT");
+        }
+
+        [Test]
+        public void BoundStatement_With_PreparedLwt_Should_Be_Lwt()
+        {
+            var ps = new PreparedStatement();
+            ps.SetLwt(true);
+            var bound = new BoundStatement(ps);
+            bound.SetConsistencyLevel(ConsistencyLevel.Quorum);
+            Assert.True(bound.IsLwt(), "BoundStatement from LWT prepared statement should be confirmed LWT");
+            Assert.True(bound.ShouldRouteAsLwt(), "BoundStatement from LWT prepared statement should route as LWT");
+        }
+
+        [Test]
+        public void BoundStatement_Without_Serial_Or_PreparedLwt_Should_Not_Be_Lwt()
+        {
+            var ps = new PreparedStatement();
+            ps.SetLwt(false);
+            var bound = new BoundStatement(ps);
+            bound.SetConsistencyLevel(ConsistencyLevel.One);
+            Assert.False(bound.IsLwt(), "BoundStatement without serial CL or prepared LWT should not be detected as LWT");
+            Assert.False(bound.ShouldRouteAsLwt(), "BoundStatement without serial CL or prepared LWT should not route as LWT");
+        }
+
+        [Test]
+        public void RetryPolicy_Should_Not_Downgrade_Serial_Consistency_On_ReadTimeout()
+        {
+            var config = new Configuration();
+            var policy = DowngradingConsistencyRetryPolicy.Instance.Wrap(Cassandra.Policies.DefaultExtendedRetryPolicy);
+            var statement = new SimpleStatement("SELECT v FROM ks.t WHERE pk = ?");
+            statement.SetConsistencyLevel(ConsistencyLevel.Serial);
+            statement.SetRetryPolicy(policy);
+
+            // Simulate a read timeout with Serial consistency where 1 of 2 responded (received < required triggers downgrade)
+            var decision = RequestHandlerTests.GetRetryDecisionFromServerError(
+                new ReadTimeoutException(ConsistencyLevel.Serial, 1, 2, false),
+                policy, statement, config, 0);
+
+            // The downgrading policy would normally retry at CL.One, but serial should not be downgraded
+            Assert.AreEqual(RetryDecision.RetryDecisionType.Rethrow, decision.DecisionType,
+                "Retry policy should not downgrade Serial consistency");
+        }
+
+        [Test]
+        public void RetryPolicy_Should_Not_Downgrade_LocalSerial_Consistency_On_ReadTimeout()
+        {
+            var config = new Configuration();
+            var policy = DowngradingConsistencyRetryPolicy.Instance.Wrap(Cassandra.Policies.DefaultExtendedRetryPolicy);
+            var statement = new SimpleStatement("SELECT v FROM ks.t WHERE pk = ?");
+            statement.SetConsistencyLevel(ConsistencyLevel.LocalSerial);
+            statement.SetRetryPolicy(policy);
+
+            var decision = RequestHandlerTests.GetRetryDecisionFromServerError(
+                new ReadTimeoutException(ConsistencyLevel.LocalSerial, 1, 2, false),
+                policy, statement, config, 0);
+
+            Assert.AreEqual(RetryDecision.RetryDecisionType.Rethrow, decision.DecisionType,
+                "Retry policy should not downgrade LocalSerial consistency");
+        }
+
+        [Test]
+        public void RetryPolicy_Should_Not_Downgrade_Serial_Consistency_On_Unavailable()
+        {
+            var config = new Configuration();
+            var policy = DowngradingConsistencyRetryPolicy.Instance.Wrap(Cassandra.Policies.DefaultExtendedRetryPolicy);
+            var statement = new SimpleStatement("SELECT v FROM ks.t WHERE pk = ?");
+            statement.SetConsistencyLevel(ConsistencyLevel.Serial);
+            statement.SetRetryPolicy(policy);
+
+            var decision = RequestHandlerTests.GetRetryDecisionFromServerError(
+                new UnavailableException(ConsistencyLevel.Serial, 2, 1),
+                policy, statement, config, 0);
+
+            Assert.AreEqual(RetryDecision.RetryDecisionType.Rethrow, decision.DecisionType,
+                "Retry policy should not downgrade Serial consistency on unavailable");
+        }
+
+        [Test]
+        public void RetryPolicy_Should_Allow_Retry_With_Same_Serial_Consistency()
+        {
+            var config = new Configuration();
+            // DefaultRetryPolicy retries at same CL on read timeout when data not retrieved
+            var policy = new DefaultRetryPolicy();
+            var statement = new SimpleStatement("SELECT v FROM ks.t WHERE pk = ?");
+            statement.SetConsistencyLevel(ConsistencyLevel.Serial);
+            statement.SetRetryPolicy(policy);
+
+            // receivedResponses >= requiredResponses and !dataRetrieved => retry at same CL
+            var decision = RequestHandlerTests.GetRetryDecisionFromServerError(
+                new ReadTimeoutException(ConsistencyLevel.Serial, 2, 2, false),
+                policy, statement, config, 0);
+
+            // Retrying at Serial is OK (no downgrade)
+            Assert.AreEqual(RetryDecision.RetryDecisionType.Retry, decision.DecisionType,
+                "Retry at same serial consistency should be allowed");
+            Assert.AreEqual(ConsistencyLevel.Serial, decision.RetryConsistencyLevel,
+                "Retry should keep Serial consistency level");
+            Assert.IsTrue(decision.UseCurrentHost,
+                "LWT retry should use current host");
+        }
+
+        [Test]
+        public void RetryPolicy_Should_Rethrow_On_Unavailable_With_Serial_Consistency_Even_If_Policy_Retries_At_Same_Cl()
+        {
+            var config = new Configuration();
+            // Create a policy that retries at the same serial CL on unavailable
+            var mockPolicy = new Mock<IExtendedRetryPolicy>();
+            mockPolicy
+                .Setup(p => p.OnUnavailable(It.IsAny<IStatement>(), It.IsAny<ConsistencyLevel>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()))
+                .Returns(RetryDecision.Retry(ConsistencyLevel.Serial, true));
+            var statement = new SimpleStatement("SELECT v FROM ks.t WHERE pk = ?");
+            statement.SetConsistencyLevel(ConsistencyLevel.Serial);
+            statement.SetRetryPolicy(mockPolicy.Object);
+
+            var decision = RequestHandlerTests.GetRetryDecisionFromServerError(
+                new UnavailableException(ConsistencyLevel.Serial, 2, 1),
+                mockPolicy.Object, statement, config, 0);
+
+            // Even if the policy says retry at same serial CL, UnavailableException means node is down - must rethrow
+            Assert.AreEqual(RetryDecision.RetryDecisionType.Rethrow, decision.DecisionType,
+                "UnavailableException with serial consistency should always rethrow for LWT safety");
+        }
+
+        [Test]
+        public void RetryPolicy_Should_Force_Current_Host_On_ReadTimeout_With_Serial_Consistency()
+        {
+            var config = new Configuration();
+            // Create a policy that retries on a different host
+            var mockPolicy = new Mock<IExtendedRetryPolicy>();
+            mockPolicy
+                .Setup(p => p.OnReadTimeout(It.IsAny<IStatement>(), It.IsAny<ConsistencyLevel>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<int>()))
+                .Returns(RetryDecision.Retry(ConsistencyLevel.Serial, false));
+            var statement = new SimpleStatement("SELECT v FROM ks.t WHERE pk = ?");
+            statement.SetConsistencyLevel(ConsistencyLevel.Serial);
+            statement.SetRetryPolicy(mockPolicy.Object);
+
+            var decision = RequestHandlerTests.GetRetryDecisionFromServerError(
+                new ReadTimeoutException(ConsistencyLevel.Serial, 2, 2, false),
+                mockPolicy.Object, statement, config, 0);
+
+            // For LWT read timeout (node is up), retry must stay on current host
+            Assert.AreEqual(RetryDecision.RetryDecisionType.Retry, decision.DecisionType,
+                "ReadTimeout with serial consistency should allow retry");
+            Assert.AreEqual(ConsistencyLevel.Serial, decision.RetryConsistencyLevel,
+                "Retry should keep Serial consistency level");
+            Assert.IsTrue(decision.UseCurrentHost,
+                "LWT retry on ReadTimeout should be forced to use current host");
+        }
+
+        [Test]
+        public void RetryPolicy_Should_Force_Current_Host_On_WriteTimeout_With_Serial_Consistency()
+        {
+            var config = new Configuration();
+            // Create a policy that retries on a different host
+            var mockPolicy = new Mock<IExtendedRetryPolicy>();
+            mockPolicy
+                .Setup(p => p.OnWriteTimeout(It.IsAny<IStatement>(), It.IsAny<ConsistencyLevel>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()))
+                .Returns(RetryDecision.Retry(ConsistencyLevel.Serial, false));
+            var statement = new SimpleStatement("SELECT v FROM ks.t WHERE pk = ?");
+            statement.SetConsistencyLevel(ConsistencyLevel.Serial);
+            statement.SetRetryPolicy(mockPolicy.Object);
+
+            var decision = RequestHandlerTests.GetRetryDecisionFromServerError(
+                new WriteTimeoutException(ConsistencyLevel.Serial, 2, 2, "CAS"),
+                mockPolicy.Object, statement, config, 0);
+
+            // For LWT write timeout (node is up), retry must stay on current host
+            Assert.AreEqual(RetryDecision.RetryDecisionType.Retry, decision.DecisionType,
+                "WriteTimeout with serial consistency should allow retry");
+            Assert.AreEqual(ConsistencyLevel.Serial, decision.RetryConsistencyLevel,
+                "Retry should keep Serial consistency level");
+            Assert.IsTrue(decision.UseCurrentHost,
+                "LWT retry on WriteTimeout should be forced to use current host");
+        }
+
+        [Test]
+        public void RetryPolicy_Should_Allow_Downgrade_For_NonSerial_Consistency()
+        {
+            var config = new Configuration();
+            var policy = DowngradingConsistencyRetryPolicy.Instance.Wrap(Cassandra.Policies.DefaultExtendedRetryPolicy);
+            var statement = new SimpleStatement("SELECT v FROM ks.t WHERE pk = ?");
+            statement.SetConsistencyLevel(ConsistencyLevel.Quorum);
+            statement.SetRetryPolicy(policy);
+
+            // received < required triggers downgrade to CL.One — guard should not interfere for non-serial
+            var decision = RequestHandlerTests.GetRetryDecisionFromServerError(
+                new ReadTimeoutException(ConsistencyLevel.Quorum, 1, 3, false),
+                policy, statement, config, 0);
+
+            // DowngradingConsistencyRetryPolicy downgrades to CL.One - that's fine for non-serial
+            Assert.AreEqual(RetryDecision.RetryDecisionType.Retry, decision.DecisionType,
+                "Downgrade for non-serial consistency should still be allowed");
+        }
+    }
+}

--- a/src/Cassandra/BoundStatement.cs
+++ b/src/Cassandra/BoundStatement.cs
@@ -83,6 +83,11 @@ namespace Cassandra
             return _preparedStatement.IsLwt;
         }
 
+        public override bool ShouldRouteAsLwt()
+        {
+            return IsLwt() || ConsistencyLevel?.IsSerialConsistencyLevel() == true;
+        }
+
         public BoundStatement SetLwt(bool isLwt)
         {
             _preparedStatement.SetLwt(isLwt);

--- a/src/Cassandra/IStatement.cs
+++ b/src/Cassandra/IStatement.cs
@@ -142,7 +142,18 @@ namespace Cassandra
 
         string TableName { get; }
 
+        /// <summary>
+        /// Returns whether this statement is a confirmed LWT (lightweight transaction),
+        /// based on prepared statement metadata or explicit marking.
+        /// </summary>
         bool IsLwt();
+
+        /// <summary>
+        /// Returns whether this statement should be routed as an LWT.
+        /// This considers both <see cref="IsLwt()"/> and whether the statement's
+        /// consistency level is serial (<c>SERIAL</c> or <c>LOCAL_SERIAL</c>).
+        /// </summary>
+        bool ShouldRouteAsLwt();
 
         /// <summary>
         /// Sets the paging behavior.

--- a/src/Cassandra/Policies/DCAwareRoundRobinPolicy.cs
+++ b/src/Cassandra/Policies/DCAwareRoundRobinPolicy.cs
@@ -31,7 +31,7 @@ namespace Cassandra
     /// See the comments on <see cref="DCAwareRoundRobinPolicy(string, int)"/> for more information.
     /// </para>
     /// </summary>
-    public class DCAwareRoundRobinPolicy : ILoadBalancingPolicy
+    public class DCAwareRoundRobinPolicy : IExtendedLoadBalancingPolicy
     {
         private const string UsedHostsPerRemoteDcObsoleteMessage =
             "The usedHostsPerRemoteDc parameter will be removed in the next major release of the driver. " +
@@ -70,7 +70,7 @@ namespace Cassandra
         ///  Creates a new datacenter aware round robin policy given the name of the local
         ///  datacenter. <p> The name of the local datacenter provided must be the local
         ///  datacenter name as known by Cassandra. </p><p> The policy created will ignore all
-        ///  remote hosts. In other words, this is equivalent to 
+        ///  remote hosts. In other words, this is equivalent to
         ///  <c>new DCAwareRoundRobinPolicy(localDc, 0)</c>.</p>
         /// </summary>
         /// <param name="localDc"> the name of the local datacenter (as known by Cassandra).</param>
@@ -204,8 +204,14 @@ namespace Cassandra
         ///  first for querying, which one to use as failover, etc...</returns>
         public IEnumerable<HostShard> NewQueryPlan(string keyspace, IStatement query)
         {
+            return NewQueryPlan(keyspace, query, query?.ShouldRouteAsLwt() == true);
+        }
+
+        /// <inheritdoc />
+        public IEnumerable<HostShard> NewQueryPlan(string keyspace, IStatement query, bool routeAsLwt)
+        {
             var startIndex = 0;
-            if (query?.IsLwt() != true)
+            if (!routeAsLwt)
             {
                 startIndex = Interlocked.Increment(ref _index);
                 //Simplified overflow protection
@@ -280,7 +286,7 @@ namespace Cassandra
                 //shallow copy the nodes
                 var allNodes = _cluster.AllHosts().ToArray();
 
-                //Split between local and remote nodes 
+                //Split between local and remote nodes
                 foreach (var h in allNodes)
                 {
                     if (GetDatacenter(h) == _localDc)

--- a/src/Cassandra/Policies/DefaultLoadBalancingPolicy.cs
+++ b/src/Cassandra/Policies/DefaultLoadBalancingPolicy.cs
@@ -30,7 +30,7 @@ namespace Cassandra
     /// returned for other workloads.
     /// </para>
     /// </summary>
-    public class DefaultLoadBalancingPolicy : ILoadBalancingPolicy
+    public class DefaultLoadBalancingPolicy : IExtendedLoadBalancingPolicy
     {
         private volatile Host _lastPreferredHost;
 
@@ -93,6 +93,23 @@ namespace Cassandra
             {
                 _lastPreferredHost = targetedStatement.PreferredHost;
                 return YieldPreferred(keyspace, targetedStatement);
+            }
+
+            return ChildPolicy.NewQueryPlan(keyspace, statement);
+        }
+
+        /// <inheritdoc />
+        public IEnumerable<HostShard> NewQueryPlan(string keyspace, IStatement statement, bool routeAsLwt)
+        {
+            if (statement is TargettedSimpleStatement targetedStatement && targetedStatement.PreferredHost != null)
+            {
+                _lastPreferredHost = targetedStatement.PreferredHost;
+                return YieldPreferred(keyspace, targetedStatement);
+            }
+
+            if (ChildPolicy is IExtendedLoadBalancingPolicy extendedChild)
+            {
+                return extendedChild.NewQueryPlan(keyspace, statement, routeAsLwt);
             }
 
             return ChildPolicy.NewQueryPlan(keyspace, statement);

--- a/src/Cassandra/Policies/IExtendedLoadBalancingPolicy.cs
+++ b/src/Cassandra/Policies/IExtendedLoadBalancingPolicy.cs
@@ -1,0 +1,44 @@
+//
+//      Copyright (C) DataStax Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+using System.Collections.Generic;
+
+namespace Cassandra
+{
+    /// <summary>
+    /// Extends <see cref="ILoadBalancingPolicy"/> with an overload of
+    /// <see cref="ILoadBalancingPolicy.NewQueryPlan(string, IStatement)"/> that accepts
+    /// an additional <c>routeAsLwt</c> flag. This allows the driver to inform the policy
+    /// whether the request should be routed as a lightweight transaction (LWT), taking
+    /// into account the effective consistency level from request options or execution
+    /// profiles, which may not be set on the statement itself.
+    /// </summary>
+    public interface IExtendedLoadBalancingPolicy : ILoadBalancingPolicy
+    {
+        /// <summary>
+        /// Returns the hosts to use for a new query, with an explicit flag indicating
+        /// whether the request should be routed as LWT.
+        /// </summary>
+        /// <param name="keyspace">Keyspace on which the query is going to be executed.</param>
+        /// <param name="query">The query for which to build a plan, it can be null.</param>
+        /// <param name="routeAsLwt">
+        /// When <c>true</c>, the policy should treat this request as a lightweight
+        /// transaction for routing purposes (e.g. always start from the same replica).
+        /// </param>
+        /// <returns>An iterator of hosts to try in order.</returns>
+        IEnumerable<HostShard> NewQueryPlan(string keyspace, IStatement query, bool routeAsLwt);
+    }
+}

--- a/src/Cassandra/Policies/RoundRobinPolicy.cs
+++ b/src/Cassandra/Policies/RoundRobinPolicy.cs
@@ -33,7 +33,7 @@ namespace Cassandra
     ///  <see cref="DCAwareRoundRobinPolicy"/> load balancing policy instead.
     /// </para>
     /// </summary>
-    public class RoundRobinPolicy : ILoadBalancingPolicy
+    public class RoundRobinPolicy : IExtendedLoadBalancingPolicy
     {
         ICluster _cluster;
         int _index;
@@ -68,10 +68,16 @@ namespace Cassandra
         ///  first for querying, which one to use as failover, etc...</returns>
         public IEnumerable<HostShard> NewQueryPlan(string keyspace, IStatement query)
         {
+            return NewQueryPlan(keyspace, query, query?.ShouldRouteAsLwt() == true);
+        }
+
+        /// <inheritdoc />
+        public IEnumerable<HostShard> NewQueryPlan(string keyspace, IStatement query, bool routeAsLwt)
+        {
             //shallow copy the all hosts
             var hosts = (from h in _cluster.AllHosts() select h).ToArray();
             var startIndex = 0;
-            if (query?.IsLwt() != true)
+            if (!routeAsLwt)
             {
                 startIndex = Interlocked.Increment(ref _index);
 

--- a/src/Cassandra/Policies/TokenAwarePolicy.cs
+++ b/src/Cassandra/Policies/TokenAwarePolicy.cs
@@ -32,7 +32,7 @@ namespace Cassandra
     /// </item>
     /// </list>
     /// </summary>
-    public class TokenAwarePolicy : ILoadBalancingPolicy
+    public class TokenAwarePolicy : IExtendedLoadBalancingPolicy
     {
         private ICluster _cluster;
         private readonly ThreadLocal<Random> _prng = new ThreadLocal<Random>(() => new Random(
@@ -82,11 +82,19 @@ namespace Cassandra
         /// <returns>the new query plan.</returns>
         public IEnumerable<HostShard> NewQueryPlan(string loggedKeyspace, IStatement query)
         {
+            return NewQueryPlan(loggedKeyspace, query, query?.ShouldRouteAsLwt() == true);
+        }
+
+        /// <inheritdoc />
+        public IEnumerable<HostShard> NewQueryPlan(string loggedKeyspace, IStatement query, bool routeAsLwt)
+        {
             var routingKey = query?.RoutingKey;
             IEnumerable<HostShard> childIterator;
             if (routingKey == null)
             {
-                childIterator = ChildPolicy.NewQueryPlan(loggedKeyspace, query);
+                childIterator = ChildPolicy is IExtendedLoadBalancingPolicy extChild
+                    ? extChild.NewQueryPlan(loggedKeyspace, query, routeAsLwt)
+                    : ChildPolicy.NewQueryPlan(loggedKeyspace, query);
                 foreach (var h in childIterator)
                 {
                     yield return h;
@@ -119,8 +127,8 @@ namespace Cassandra
             if (localReplicaList.Count > 0)
             {
                 var startIndex = 0;
-                // Use a pseudo random start index if query is not LWT
-                if (query?.IsLwt() != true)
+                // Use a pseudo random start index if query should not be routed as LWT
+                if (!routeAsLwt)
                 {
                     startIndex = _prng.Value.Next();
                 }
@@ -131,7 +139,9 @@ namespace Cassandra
             }
 
             // Then, return the rest of child policy hosts
-            childIterator = ChildPolicy.NewQueryPlan(loggedKeyspace, query);
+            childIterator = ChildPolicy is IExtendedLoadBalancingPolicy extChild2
+                ? extChild2.NewQueryPlan(loggedKeyspace, query, routeAsLwt)
+                : ChildPolicy.NewQueryPlan(loggedKeyspace, query);
             foreach (var h in childIterator)
             {
                 if (localReplicaSet.Contains(h))

--- a/src/Cassandra/Requests/RequestExecution.cs
+++ b/src/Cassandra/Requests/RequestExecution.cs
@@ -500,7 +500,7 @@ namespace Cassandra.Requests
 
             if (ex is ReadTimeoutException e)
             {
-                return new RetryDecisionWithReason(
+                return GuardSerialConsistencyDowngrade(new RetryDecisionWithReason(
                     policy.OnReadTimeout(
                         statement,
                         e.ConsistencyLevel,
@@ -509,12 +509,12 @@ namespace Cassandra.Requests
                         e.WasDataRetrieved,
                         retryCount),
                     RequestErrorType.ReadTimeOut
-                );
+                ), e.ConsistencyLevel);
             }
 
             if (ex is WriteTimeoutException e1)
             {
-                return new RetryDecisionWithReason(
+                return GuardSerialConsistencyDowngrade(new RetryDecisionWithReason(
                     policy.OnWriteTimeout(
                         statement,
                         e1.ConsistencyLevel,
@@ -523,19 +523,55 @@ namespace Cassandra.Requests
                         e1.ReceivedAcknowledgements,
                         retryCount),
                     RequestErrorType.WriteTimeOut
-                );
+                ), e1.ConsistencyLevel);
             }
 
             if (ex is UnavailableException e2)
             {
-                return new RetryDecisionWithReason(
+                return GuardSerialConsistencyDowngrade(new RetryDecisionWithReason(
                     policy.OnUnavailable(statement, e2.Consistency, e2.RequiredReplicas, e2.AliveReplicas, retryCount),
                     RequestErrorType.Unavailable
-                );
+                ), e2.Consistency);
             }
 
             // Any other Exception just throw it
             return new RetryDecisionWithReason(RetryDecision.Rethrow(), RequestExecution.GetErrorType(error));
+        }
+
+        /// Guards retry decisions for requests whose original consistency level is serial
+        /// (<c>SERIAL</c> or <c>LOCAL_SERIAL</c>).
+        /// For retry decisions on serial-consistency requests:
+        /// - <c>Unavailable</c>: rethrow instead of retrying
+        /// - Retry with a non-serial consistency level: rethrow instead of downgrading consistency
+        internal static RetryDecisionWithReason GuardSerialConsistencyDowngrade(RetryDecisionWithReason result, ConsistencyLevel originalCl)
+        {
+            if (!originalCl.IsSerialConsistencyLevel() || result.Decision.DecisionType != RetryDecision.RetryDecisionType.Retry)
+            {
+                return result;
+            }
+
+            // UnavailableException means the target node is down - always rethrow for LWT
+            if (result.Reason == RequestErrorType.Unavailable)
+            {
+                return new RetryDecisionWithReason(RetryDecision.Rethrow(), result.Reason);
+            }
+
+            // For ReadTimeout/WriteTimeout: node is up, prevent CL downgrade and force retry on current host
+            if (result.Decision.RetryConsistencyLevel.HasValue
+                && result.Decision.RetryConsistencyLevel.Value != originalCl)
+            {
+                return new RetryDecisionWithReason(RetryDecision.Rethrow(), result.Reason);
+            }
+
+            // Ensure retry stays on the current host for LWT
+            if (!result.Decision.UseCurrentHost)
+            {
+                return new RetryDecisionWithReason(
+                    RetryDecision.Retry(result.Decision.RetryConsistencyLevel, true),
+                    result.Reason);
+            }
+
+            return result;
         }
 
         internal static RequestErrorType GetErrorType(IRequestError error)

--- a/src/Cassandra/Requests/RequestHandler.cs
+++ b/src/Cassandra/Requests/RequestHandler.cs
@@ -82,7 +82,7 @@ namespace Cassandra.Requests
                 RetryPolicy = sessionRequestInfo.Statement.RetryPolicy.Wrap(RetryPolicy);
             }
 
-            _queryPlan = RequestHandler.GetQueryPlan(session, sessionRequestInfo.Statement, RequestOptions.LoadBalancingPolicy).GetEnumerator();
+            _queryPlan = RequestHandler.GetQueryPlan(session, sessionRequestInfo.Statement, RequestOptions.LoadBalancingPolicy, RequestOptions).GetEnumerator();
         }
 
         /// <summary>
@@ -107,14 +107,29 @@ namespace Cassandra.Requests
         /// In the special case when a Host is provided at Statement level, it will return a query plan with a single
         /// host.
         /// </summary>
-        private static IEnumerable<HostShard> GetQueryPlan(ISession session, IStatement statement, ILoadBalancingPolicy lbp)
+        private static IEnumerable<HostShard> GetQueryPlan(ISession session, IStatement statement, ILoadBalancingPolicy lbp, IRequestOptions requestOptions)
         {
             // Single host iteration
             var host = (statement as Statement)?.Host;
 
-            return host == null
-                ? lbp.NewQueryPlan(session.Keyspace, statement)
-                : Enumerable.Repeat(new HostShard(host, -1), 1);
+            if (host != null)
+            {
+                return Enumerable.Repeat(new HostShard(host, -1), 1);
+            }
+
+            // Determine whether to route as LWT: either the statement itself says so,
+            // or the effective CL from requestOptions/execution profile is serial.
+            var routeAsLwt = statement?.ShouldRouteAsLwt() == true
+                || (statement is Statement stmt
+                    && stmt.ConsistencyLevel == null
+                    && requestOptions.ConsistencyLevel.IsSerialConsistencyLevel());
+
+            if (lbp is IExtendedLoadBalancingPolicy extendedLbp)
+            {
+                return extendedLbp.NewQueryPlan(session.Keyspace, statement, routeAsLwt);
+            }
+
+            return lbp.NewQueryPlan(session.Keyspace, statement);
         }
 
         /// <inheritdoc />

--- a/src/Cassandra/Statement.cs
+++ b/src/Cassandra/Statement.cs
@@ -48,7 +48,7 @@ namespace Cassandra
 
         /// <summary>
         /// Gets the serial consistency level for this query.
-        /// </summary>        
+        /// </summary>
         public ConsistencyLevel SerialConsistencyLevel
         {
             get { return _serialConsistency; }
@@ -175,7 +175,7 @@ namespace Cassandra
         ///  one call.
         /// </summary>
         /// <param name="values"> the values to bind to the variables of the newly
-        ///  created BoundStatement. The first element of <c>values</c> will 
+        ///  created BoundStatement. The first element of <c>values</c> will
         ///  be bound to the first bind variable,
         ///  etc.. It is legal to provide less values than the statement has bound
         ///  variables. In that case, the remaining variable need to be bound before
@@ -315,6 +315,11 @@ namespace Cassandra
         public virtual bool IsLwt()
         {
             return false;
+        }
+
+        public virtual bool ShouldRouteAsLwt()
+        {
+            return IsLwt() || ConsistencyLevel?.IsSerialConsistencyLevel() == true;
         }
     }
 }


### PR DESCRIPTION
The server cannot mark SELECT statements as LWT during PREPARE because the consistency level is only provided at EXECUTE time. This PR adds client-side detection so that any statement executed with regular consistency SERIAL or LOCAL_SERIAL is routed like an LWT (to a single replica owner).

Fixes: https://scylladb.atlassian.net/browse/DRIVER-617