### PR TITLE
Use explicit column names in system table queries in TopologyRefresher

### DIFF
--- a/src/Cassandra.IntegrationTests/Core/ClusterSimulacronTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ClusterSimulacronTests.cs
@@ -22,6 +22,7 @@ using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Cassandra.Connections.Control;
 using Cassandra.IntegrationTests.SimulacronAPI.PrimeBuilder.Then;
 using Cassandra.IntegrationTests.TestClusterManagement.Simulacron;
 using Cassandra.Tasks;
@@ -48,14 +49,17 @@ namespace Cassandra.IntegrationTests.Core
 
             try
             {
+                var selectPeersV2 = TopologyRefresher.SelectPeersV2;
+                var selectPeers = TopologyRefresher.SelectPeers;
+
                 TestCluster.PrimeFluent(
-                    p => p.WhenQuery("SELECT * FROM system.peers_v2")
+                    p => p.WhenQuery(selectPeersV2)
                           .ThenServerError(ServerError.Invalid, "error"));
 
                 SetupNewSession(b => b.WithPoolingOptions(new PoolingOptions().SetHeartBeatInterval(3000)));
 
-                var peersV2Queries = TestCluster.GetQueries("SELECT * FROM system.peers_v2");
-                var peersQueries = TestCluster.GetQueries("SELECT * FROM system.peers");
+                var peersV2Queries = TestCluster.GetQueries(selectPeersV2);
+                var peersQueries = TestCluster.GetQueries(selectPeers);
 
                 var oldCcHost = Session.Cluster.Metadata.ControlConnection.Host;
 
@@ -86,8 +90,8 @@ namespace Cassandra.IntegrationTests.Core
                     200,
                     100);
 
-                var afterPeersV2Queries = TestCluster.GetQueries("SELECT * FROM system.peers_v2");
-                var afterPeersQueries = TestCluster.GetQueries("SELECT * FROM system.peers");
+                var afterPeersV2Queries = TestCluster.GetQueries(selectPeersV2);
+                var afterPeersQueries = TestCluster.GetQueries(selectPeers);
 
                 Assert.AreEqual(peersV2Queries.Count, afterPeersV2Queries.Count);
                 Assert.GreaterOrEqual(afterPeersQueries.Count, peersQueries.Count + 2);

--- a/src/Cassandra.Tests/Connections/Control/TopologyRefresherTests.cs
+++ b/src/Cassandra.Tests/Connections/Control/TopologyRefresherTests.cs
@@ -33,9 +33,9 @@ namespace Cassandra.Tests.Connections.Control
     [TestFixture]
     public class TopologyRefresherTests
     {
-        private const string LocalQuery = "SELECT * FROM system.local WHERE key='local'";
-        private const string PeersQuery = "SELECT * FROM system.peers";
-        private const string PeersV2Query = "SELECT * FROM system.peers_v2";
+        private const string LocalQuery = "SELECT broadcast_address, cluster_name, data_center, host_id, listen_address, partitioner, rack, release_version, rpc_address, schema_version, tokens FROM system.local WHERE key='local'";
+        private const string PeersQuery = "SELECT peer, data_center, host_id, rack, release_version, rpc_address, schema_version, tokens FROM system.peers";
+        private const string PeersV2Query = "SELECT peer, data_center, host_id, native_address, native_port, rack, release_version, schema_version, tokens FROM system.peers_v2";
 
         private Metadata _metadata;
 

--- a/src/Cassandra/Connections/Control/TopologyRefresher.cs
+++ b/src/Cassandra/Connections/Control/TopologyRefresher.cs
@@ -1,12 +1,12 @@
-﻿// 
+﻿//
 //       Copyright (C) DataStax Inc.
-// 
+//
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
 //    You may obtain a copy of the License at
-// 
+//
 //       http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 //    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,9 +27,11 @@ namespace Cassandra.Connections.Control
     /// <inheritdoc />
     internal class TopologyRefresher : ITopologyRefresher
     {
-        private const string SelectPeers = "SELECT * FROM system.peers";
-        private const string SelectPeersV2 = "SELECT * FROM system.peers_v2";
-        private const string SelectLocal = "SELECT * FROM system.local WHERE key='local'";
+        // NOTE: Before adding a new column name to these queries, verify that the column
+        // is available across all supported Scylla versions.
+        internal const string SelectPeers = "SELECT peer, data_center, host_id, rack, release_version, rpc_address, schema_version, tokens FROM system.peers";
+        internal const string SelectPeersV2 = "SELECT peer, data_center, host_id, native_address, native_port, rack, release_version, schema_version, tokens FROM system.peers_v2";
+        internal const string SelectLocal = "SELECT broadcast_address, cluster_name, data_center, host_id, listen_address, partitioner, rack, release_version, rpc_address, schema_version, tokens FROM system.local WHERE key='local'";
 
         private static readonly IPAddress BindAllAddress = new IPAddress(new byte[4]);
 


### PR DESCRIPTION
Replace SELECT * with explicit column lists for system.local, system.peers, and system.peers_v2 queries. This avoids fetching unnecessary columns and makes the driver resilient to schema changes in system tables.

Update the integration test to match the new query strings.

Fixes: https://scylladb.atlassian.net/browse/DRIVER-369