### PR TITLE
Execute lwt tests only on scylla versions that supports lwt with tablets

### DIFF
--- a/src/Cassandra.IntegrationTests/Mapping/Tests/Delete.cs
+++ b/src/Cassandra.IntegrationTests/Mapping/Tests/Delete.cs
@@ -162,7 +162,7 @@ namespace Cassandra.IntegrationTests.Mapping.Tests
             Assert.Throws<AggregateException>(() => _mapper.DeleteAsync(movieToDelete, new CqlQueryOptions().SetConsistencyLevel(ConsistencyLevel.Three)).Wait());
         }
 
-        [Test]
+        [Test, TestScyllaVersion(2026, 1)]
         public void DeleteIf_Applied_Test()
         {
             var config = new MappingConfiguration()

--- a/src/Cassandra.IntegrationTests/Mapping/Tests/InsertTests.cs
+++ b/src/Cassandra.IntegrationTests/Mapping/Tests/InsertTests.cs
@@ -393,7 +393,7 @@ namespace Cassandra.IntegrationTests.Mapping.Tests
             StringAssert.Contains(expectedMessage, ex.Message);
         }
 
-        [Test]
+        [Test, TestScyllaVersion(2026, 1)]
         public void InsertIfNotExists_Applied_Test()
         {
             var config = new MappingConfiguration()

--- a/src/Cassandra.IntegrationTests/Mapping/Tests/Update.cs
+++ b/src/Cassandra.IntegrationTests/Mapping/Tests/Update.cs
@@ -61,7 +61,7 @@ namespace Cassandra.IntegrationTests.Mapping.Tests
 
         /// <summary>
         /// Attempt to update a single record to the same values, validate that the record is not altered.
-        /// 
+        ///
         /// @test_category queries:basic
         /// </summary>
         [Test]
@@ -80,7 +80,7 @@ namespace Cassandra.IntegrationTests.Mapping.Tests
 
         /// <summary>
         /// Update a single record to different values, validate that the resultant data in Cassandra is correct.
-        /// 
+        ///
         /// @test_category queries:basic
         /// </summary>
         [Test]
@@ -100,7 +100,7 @@ namespace Cassandra.IntegrationTests.Mapping.Tests
             Assert.IsFalse(Movie.ListContains(actualMovieList, movieToUpdate));
         }
 
-        [Test]
+        [Test, TestScyllaVersion(2026, 1)]
         public void UpdateIf_Applied_Test()
         {
             var config = new MappingConfiguration()
@@ -125,7 +125,7 @@ namespace Cassandra.IntegrationTests.Mapping.Tests
 
         /// <summary>
         /// Attempt to update a record without defining the partition key
-        /// 
+        ///
         /// @test_category queries:basic
         /// </summary>
         [Test]

--- a/src/Cassandra.IntegrationTests/OpenTelemetry/OpenTelemetryTests.cs
+++ b/src/Cassandra.IntegrationTests/OpenTelemetry/OpenTelemetryTests.cs
@@ -211,7 +211,7 @@ namespace Cassandra.IntegrationTests.OpenTelemetry
         }
 
         [Category(TestCategory.RealCluster)]
-        [Test]
+        [Test, TestScyllaVersion(2026, 1)]
         public async Task AddOpenTelemetry_MapperAndMapperAsync_SessionRequestIsParentOfNodeRequest()
         {
             var testProfile = "testProfile";


### PR DESCRIPTION
Fixes CI failures on older versions.