### PR TITLE
Fix shard-aware pool connection balancing

### DIFF
--- a/src/Cassandra.Tests/HostConnectionPoolTests.cs
+++ b/src/Cassandra.Tests/HostConnectionPoolTests.cs
@@ -445,6 +445,37 @@ namespace Cassandra.Tests
         }
 
         [Test]
+        public async Task Reconnection_Should_Target_Missing_Shard_When_Resized_Pool_Is_Unbalanced()
+        {
+            const int shardCount = 4;
+            _mock = GetPoolMock(null, GetConfig(4, 8, new ConstantReconnectionPolicy(1)));
+            var attempts = new List<Tuple<int, int, int>>();
+            _mock
+                .Setup(p => p.DoCreateAndOpen(It.IsAny<bool>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()))
+                .Returns<bool, int, int, int>((isReconnection, shardId, shardAwarePort, count) =>
+                {
+                    attempts.Add(Tuple.Create(shardId, shardAwarePort, count));
+                    return TaskHelper.ToTask(GetShardedConnectionMock(shardId == -1 ? 0 : shardId, shardCount, 1500));
+                });
+
+            var pool = _mock.Object;
+            pool.SetDistance(HostDistance.Local);
+            await pool.Warmup().ConfigureAwait(false);
+            pool.ConsiderResizingPool(1500);
+            await TestHelper.WaitUntilAsync(() => pool.OpenConnections == 5).ConfigureAwait(false);
+            var attemptsBeforeReplacement = attempts.Count;
+
+            var connectionToRemove = pool.ConnectionsSnapshot.First(c => c.ShardID == 2);
+            pool.OnConnectionClosing(connectionToRemove);
+
+            await TestHelper.WaitUntilAsync(() => pool.OpenConnections == 5).ConfigureAwait(false);
+            Assert.AreEqual(2, attempts[attemptsBeforeReplacement].Item1);
+            Assert.AreEqual(19042, attempts[attemptsBeforeReplacement].Item2);
+            Assert.AreEqual(shardCount, attempts[attemptsBeforeReplacement].Item3);
+            Assert.AreEqual(1, pool.ConnectionsSnapshot.Count(c => c.ShardID == 2));
+        }
+
+        [Test]
         public void MinInFlight_Returns_The_Min_Inflight_From_Two_Connections()
         {
             var connections = new ShardedList<IConnection>(new[]

--- a/src/Cassandra.Tests/HostConnectionPoolTests.cs
+++ b/src/Cassandra.Tests/HostConnectionPoolTests.cs
@@ -15,6 +15,7 @@
 //
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Net;
@@ -122,6 +123,23 @@ namespace Cassandra.Tests
             connectionMock.Setup(c => c.InFlight).Returns(inflight);
             connectionMock.Setup(c => c.TimedOutOperations).Returns(timedOutOperations);
             connectionMock.Setup(c => c.Dispose()).Raises(c => c.Closing += null, connectionMock.Object);
+            return connectionMock.Object;
+        }
+
+        private static IConnection GetShardedConnectionMock(int shardId, int shardCount, int inFlight = 0)
+        {
+            var connectionMock = new Mock<IConnection>();
+            connectionMock.SetupProperty(c => c.ShardID, shardId);
+            connectionMock.Setup(c => c.InFlight).Returns(inFlight);
+            connectionMock.Setup(c => c.ShardingInfo()).Returns(
+                ShardingInfo.Create(
+                    shardId.ToString(),
+                    shardCount.ToString(),
+                    "org.apache.cassandra.dht.Murmur3Partitioner",
+                    "biased-token-round-robin",
+                    "12",
+                    "19042",
+                    "19142"));
             return connectionMock.Object;
         }
 
@@ -364,6 +382,66 @@ namespace Cassandra.Tests
             Assert.AreEqual(3, Volatile.Read(ref creationCounter));
             Assert.AreEqual(0, Volatile.Read(ref isCreating));
             Assert.AreEqual(3, pool.OpenConnections);
+        }
+
+        [Test]
+        public async Task Warmup_Should_Target_All_Shard_Ids_When_First_Connection_Uses_High_Shard()
+        {
+            const int shardCount = 4;
+            _mock = GetPoolMock(null, GetConfig(1, 1));
+            var attempts = new List<Tuple<int, int, int>>();
+            _mock
+                .Setup(p => p.DoCreateAndOpen(It.IsAny<bool>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()))
+                .Returns<bool, int, int, int>((isReconnection, shardId, shardAwarePort, count) =>
+                {
+                    attempts.Add(Tuple.Create(shardId, shardAwarePort, count));
+                    return TaskHelper.ToTask(GetShardedConnectionMock(shardId == -1 ? 1 : shardId, shardCount));
+                });
+
+            var pool = _mock.Object;
+            pool.SetDistance(HostDistance.Local);
+
+            await pool.Warmup().ConfigureAwait(false);
+
+            Assert.AreEqual(shardCount, pool.OpenConnections);
+            for (var shardId = 0; shardId < shardCount; shardId++)
+            {
+                Assert.AreEqual(
+                    1,
+                    pool.ConnectionsSnapshot.Count(c => c.ShardID == shardId),
+                    "Unexpected number of connections for shard " + shardId);
+            }
+            CollectionAssert.AreEqual(new[] { 2, 3, 0 }, attempts.Skip(1).Select(a => a.Item1).ToArray());
+            Assert.IsTrue(attempts.Skip(1).All(a => a.Item2 == 19042 && a.Item3 == shardCount));
+        }
+
+        [Test]
+        public async Task ConsiderResizingPool_Should_Target_Shard_When_Core_Per_Shard_Is_Full()
+        {
+            const int shardCount = 4;
+            _mock = GetPoolMock(null, GetConfig(4, 8));
+            var attempts = new List<Tuple<int, int, int>>();
+            _mock
+                .Setup(p => p.DoCreateAndOpen(It.IsAny<bool>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()))
+                .Returns<bool, int, int, int>((isReconnection, shardId, shardAwarePort, count) =>
+                {
+                    attempts.Add(Tuple.Create(shardId, shardAwarePort, count));
+                    return TaskHelper.ToTask(GetShardedConnectionMock(shardId == -1 ? 0 : shardId, shardCount, 1500));
+                });
+
+            var pool = _mock.Object;
+            pool.SetDistance(HostDistance.Local);
+            await pool.Warmup().ConfigureAwait(false);
+            var attemptsBeforeResize = attempts.Count;
+
+            pool.ConsiderResizingPool(1500);
+
+            await TestHelper.WaitUntilAsync(() => pool.OpenConnections == 5).ConfigureAwait(false);
+            Assert.AreEqual(5, attempts.Count);
+            Assert.AreEqual(0, attempts[attemptsBeforeResize].Item1);
+            Assert.AreEqual(19042, attempts[attemptsBeforeResize].Item2);
+            Assert.AreEqual(shardCount, attempts[attemptsBeforeResize].Item3);
+            Assert.AreEqual(2, pool.ConnectionsSnapshot.Count(c => c.ShardID == 0));
         }
 
         [Test]

--- a/src/Cassandra/Connections/HostConnectionPool.cs
+++ b/src/Cassandra/Connections/HostConnectionPool.cs
@@ -73,7 +73,6 @@ namespace Cassandra.Connections
         private readonly ISerializerManager _serializerManager;
         private readonly IObserverFactory _observerFactory;
         private readonly CopyOnWriteShardedList<IConnection> _connections = new CopyOnWriteShardedList<IConnection>();
-        private volatile int _connectionsPerShard;
         private volatile HostDistance _distance;
         private readonly HashedWheelTimer _timer;
         private readonly SemaphoreSlim _allConnectionClosedEventLock = new SemaphoreSlim(1, 1);
@@ -782,16 +781,18 @@ namespace Cassandra.Connections
                 {
                     shardAwarePort = _config.ProtocolOptions.SslOptions != null ? shardingInfo.ScyllaShardAwarePortSSL : shardingInfo.ScyllaShardAwarePort;
                     shardCount = shardingInfo.ScyllaNrShards;
-                    // Find the shard without a connection
+                    connectionsSnapshot = _connections.GetSnapshot();
+                    var connectionsPerShard = GetConnectionsPerShardTarget(shardCount);
+                    // Find the next shard with fewer connections than the current target.
                     // It's important to start counting from 1 here because we want
-                    // to consider the next shard after the previously attempted one
+                    // to consider the next shard after the previously attempted one.
                     for (var i = 1; i <= shardCount; i++)
                     {
-                        var _shardID = (lastAttemptedShard + i) % shardCount;
-                        if (_connections.Length > _shardID && _connections.GetItemsForShard(_shardID).Length < _connectionsPerShard)
+                        var currentShardID = (lastAttemptedShard + i) % shardCount;
+                        if (connectionsSnapshot.GetItemsForShard(currentShardID).Length < connectionsPerShard)
                         {
-                            lastAttemptedShard = _shardID;
-                            shardID = _shardID;
+                            lastAttemptedShard = currentShardID;
+                            shardID = currentShardID;
                             break;
                         }
                     }
@@ -1040,9 +1041,19 @@ namespace Cassandra.Connections
                 var coreSize = _poolingOptions.GetCoreConnectionsPerHost(_distance);
                 var shardsCount = shardingInfo == null ? 1 : shardingInfo.ScyllaNrShards;
 
-                _connectionsPerShard = coreSize / shardsCount + (coreSize % shardsCount > 0 ? 1 : 0);
-                _expectedConnectionLength = shardsCount * _connectionsPerShard;
+                var connectionsPerShard = HostConnectionPool.CeilingDivide(coreSize, shardsCount);
+                _expectedConnectionLength = shardsCount * connectionsPerShard;
             }
+        }
+
+        private int GetConnectionsPerShardTarget(int shardCount)
+        {
+            return shardCount <= 0 ? 0 : HostConnectionPool.CeilingDivide(_expectedConnectionLength, shardCount);
+        }
+
+        private static int CeilingDivide(int value, int divisor)
+        {
+            return value / divisor + (value % divisor > 0 ? 1 : 0);
         }
 
         /// <summary>

--- a/src/Cassandra/Connections/HostConnectionPool.cs
+++ b/src/Cassandra/Connections/HostConnectionPool.cs
@@ -781,20 +781,10 @@ namespace Cassandra.Connections
                 {
                     shardAwarePort = _config.ProtocolOptions.SslOptions != null ? shardingInfo.ScyllaShardAwarePortSSL : shardingInfo.ScyllaShardAwarePort;
                     shardCount = shardingInfo.ScyllaNrShards;
-                    connectionsSnapshot = _connections.GetSnapshot();
-                    var connectionsPerShard = GetConnectionsPerShardTarget(shardCount);
-                    // Find the next shard with fewer connections than the current target.
-                    // It's important to start counting from 1 here because we want
-                    // to consider the next shard after the previously attempted one.
-                    for (var i = 1; i <= shardCount; i++)
+                    shardID = GetLeastRepresentedShard(shardCount);
+                    if (shardID != -1)
                     {
-                        var currentShardID = (lastAttemptedShard + i) % shardCount;
-                        if (connectionsSnapshot.GetItemsForShard(currentShardID).Length < connectionsPerShard)
-                        {
-                            lastAttemptedShard = currentShardID;
-                            shardID = currentShardID;
-                            break;
-                        }
+                        lastAttemptedShard = shardID;
                     }
                 }
                 c = await DoCreateAndOpen(isReconnection, shardID, shardAwarePort, shardCount).ConfigureAwait(false);
@@ -843,6 +833,35 @@ namespace Cassandra.Connections
             }
 
             return await FinishOpen(tcs, true, null, c).ConfigureAwait(false);
+        }
+
+        private int GetLeastRepresentedShard(int shardCount)
+        {
+            var selectedShardId = -1;
+            var selectedShardConnectionCount = int.MaxValue;
+            var connectionsPerShard = GetConnectionsPerShardTarget(shardCount);
+            var connectionsSnapshot = _connections.GetSnapshot();
+
+            // Start after the previously attempted shard to preserve round-robin
+            // behavior when multiple below-target shards have the same count.
+            for (var i = 1; i <= shardCount; i++)
+            {
+                var shardId = (lastAttemptedShard + i) % shardCount;
+                var connectionCount = connectionsSnapshot.GetItemsForShard(shardId).Length;
+                if (connectionCount >= connectionsPerShard || connectionCount >= selectedShardConnectionCount)
+                {
+                    continue;
+                }
+
+                selectedShardId = shardId;
+                selectedShardConnectionCount = connectionCount;
+                if (connectionCount == 0)
+                {
+                    break;
+                }
+            }
+
+            return selectedShardId;
         }
 
         private Task<IConnection> FinishOpen(


### PR DESCRIPTION
Fixes #241

## Summary
- choose the least represented shard for shard-aware connection opens, with round-robin only as a tie-break
- allow empty higher shard ids to be selected during warmup
- keep resize-created and replacement connections shard-pinned instead of falling back to unpinned opens
- add regression coverage for 4-shard warmup, resize, and missing-shard replacement behavior

## Tests
- dotnet test src/Cassandra.Tests/Cassandra.Tests.csproj --filter FullyQualifiedName~Cassandra.Tests.HostConnectionPoolTests
- dotnet test src/Cassandra.Tests/Cassandra.Tests.csproj