### PR TITLE
Fix NuGet publish pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ on:
         default: false
 
 env:
-  SKIP_DUPLICATE: ${{ inputs.skip-duplicate }}
+  SKIP_DUPLICATE: ${{ inputs.skip-duplicate || github.event_name == 'push' }}
   NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
   SNK_FILE: ${{ secrets.SNK_KEY }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ on:
         default: false
 
 env:
-  SKIP_DUPLICATE: ${{ inputs.skip-duplicate || github.event_name == 'push' }}
+  SKIP_DUPLICATE: ${{ inputs.skip-duplicate }}
   NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
   SNK_FILE: ${{ secrets.SNK_KEY }}
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ TARGET_FRAMEWORK ?=
 SNK_FILE ?=
 DEV_SNK_PUBLIC_KEY ?= 0024000004800000940000000602000000240000525341310004000001000100fb083dc01ba81b96b526327f232e7f4c1301c8ec177a2c66adecc315a9c2308f33ecd9dc70d6d1435107578b4dd04658c8f92a51a60d50c528ca6fba3955fa844fe79c884452024b0ba67d19a70140818aa61a1faeb23d5dcfe0bd9820d587829caf36d0ac7e0dc450d3654d5f5bee009dda3d11fd4066d4640b935c2ca048a4
 
+ifneq ($(filter true 1 yes,$(SKIP_DUPLICATE)),)
+	NUGET_PUSH_OPTIONS := --skip-duplicate
+endif
+
 ifeq (${CCM_CONFIG_DIR},)
 	CCM_CONFIG_DIR = ~/.ccm
 endif
@@ -140,12 +144,9 @@ else
 endif
 	dotnet restore $(PROJECT_PATH)
 	dotnet build $(PROJECT_PATH) --configuration Release --no-restore
+	rm -rf ./nupkgs
 	dotnet pack $(PROJECT_PATH) --configuration Release --no-build --output ./nupkgs
-ifndef SKIP_DUPLICATE
-	dotnet nuget push "./nupkgs/*.nupkg" --api-key ${NUGET_API_KEY} --source https://api.nuget.org/v3/index.json
-else
-	dotnet nuget push --skip-duplicate "./nupkgs/*.nupkg" --api-key ${NUGET_API_KEY} --source https://api.nuget.org/v3/index.json
-endif
+	dotnet nuget push ${NUGET_PUSH_OPTIONS} "./nupkgs/*.nupkg" --api-key ${NUGET_API_KEY} --source https://api.nuget.org/v3/index.json
 
 .PHONY: publish-nuget
 publish-nuget:


### PR DESCRIPTION
## What this fixes
The NuGet release pipeline can stop before publishing all packages.

`make publish-nuget` publishes three projects in sequence:

1. `src/Cassandra/Cassandra.csproj`
2. `src/Extensions/Cassandra.AppMetrics/Cassandra.AppMetrics.csproj`
3. `src/Extensions/Cassandra.OpenTelemetry/Cassandra.OpenTelemetry.csproj`

Each project packs into the same `./nupkgs` directory, then runs:

```bash
dotnet nuget push "./nupkgs/*.nupkg" ...
```

Because `./nupkgs` is not cleared between projects, later publish steps push both the newly-created package and stale packages from earlier steps. For `v3.22.0.3`, this caused the pipeline to push `ScyllaDBCSharpDriver`, then push `ScyllaDBCSharpDriver.AppMetrics`, then try to push `ScyllaDBCSharpDriver` again. NuGet returned `409 already exists`, the workflow failed, and `ScyllaDBCSharpDriver.OpenTelemetry` was never published.

## Changes
- Clear `./nupkgs` before each project is packed, so each `.publish-proj-nuget` invocation only pushes the package it just created.
- Make `SKIP_DUPLICATE` only enable `--skip-duplicate` for true-ish values (`true`, `1`, `yes`). Previously any non-empty value, including `false`, enabled duplicate skipping.

## Release behavior after this change
A tag push still runs the existing publish workflow. The difference is that each package publish step now has an isolated `nupkgs` directory, so the workflow should publish all three packages without tripping over stale packages from earlier steps.

Manual retry behavior is unchanged: if a release partially publishes and needs recovery, use workflow dispatch with `skip-duplicate=true`.

## Tests
- `git diff --check`
- `make -n .publish-proj-nuget PROJECT_PATH=src/Cassandra/Cassandra.csproj SKIP_DUPLICATE=true`
- `make -n .publish-proj-nuget PROJECT_PATH=src/Cassandra/Cassandra.csproj SKIP_DUPLICATE=false`