### PR TITLE
Sync the embedded v1 schema with the design schema

### DIFF
--- a/src/Cassandra.Tests/Requests/driver-config-report-v1.schema.json
+++ b/src/Cassandra.Tests/Requests/driver-config-report-v1.schema.json
@@ -92,8 +92,7 @@
       "description": "Per-connection CQL request and protocol stream capacity. `orphaned.max` is expected to be lower than `in-flight.max`.",
       "additionalProperties": false,
       "required": [
-        "in-flight",
-        "orphaned"
+        "in-flight"
       ],
       "properties": {
         "in-flight": {
@@ -120,7 +119,7 @@
           "properties": {
             "max": {
               "$ref": "#/$defs/nonNegativeInteger",
-              "description": "Maximum number of orphaned requests allowed on one connection before the driver closes and replaces it."
+              "description": "Maximum number of orphaned requests allowed on one connection before the driver closes and replaces it. Absent only when this bound is unknown, for example when the client never replaces a connection over accumulated orphans and so has no limit to report."
             }
           }
         }


### PR DESCRIPTION
connection.requests no longer requires orphaned: a client that never replaces a connection over accumulated orphans has no bound to report, and the schema now reads the key's absence as unknown rather than as a violation. orphaned.max carries that rationale in its description.

The embedded copy is the normative schema verbatim, so it moves with it. Nothing else does. This is a relaxation, so every document that validated before still validates, and DriverConfigReporter always reports the threshold SocketOptions.DefunctReadTimeoutThreshold gives it -- this driver does replace such a connection -- so what the reporter emits is unchanged and the conformance tests read the same.