### PR TITLE
Scope NuGet publishing secrets to publish steps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,11 +24,6 @@ on:
         type: boolean
         default: false
 
-env:
-  SKIP_DUPLICATE: ${{ inputs.skip-duplicate }}
-  NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-  SNK_FILE: ${{ secrets.SNK_KEY }}
-
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -45,8 +40,16 @@ jobs:
 
     - name: Publish to NuGet (Dry Run)
       if: ${{ inputs.dry-run == true }}
+      env:
+        SKIP_DUPLICATE: ${{ inputs.skip-duplicate }}
+        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        SNK_FILE: ${{ secrets.SNK_KEY }}
       run: make publish-nuget-dry-run
 
     - name: Publish to NuGet (Production)
       if: ${{ inputs.dry-run == false }}
+      env:
+        SKIP_DUPLICATE: ${{ inputs.skip-duplicate }}
+        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        SNK_FILE: ${{ secrets.SNK_KEY }}
       run: make publish-nuget


### PR DESCRIPTION
## Summary
- Move `NUGET_API_KEY` and `SNK_FILE` from workflow-wide environment scope to the two NuGet publish steps.
- Scope `SKIP_DUPLICATE` to the same steps.
- Prevent checkout, SDK setup, and unrelated steps from inheriting production publishing credentials.

## Security impact
Only the mutually exclusive dry-run or production publish step receives the NuGet API key and signing key. Existing publish behavior remains unchanged.

## Validation
- [x] Workflow YAML parses successfully.
- [x] `git diff --check`
- [x] Both publish paths receive all three required environment variables.

Independent security hardening found while reviewing #193.