### PR TITLE
Cache prepared statements before sending duplicate requests

### DIFF
--- a/src/Cassandra.IntegrationTests/Core/CustomPayloadTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/CustomPayloadTests.cs
@@ -107,5 +107,33 @@ namespace Cassandra.IntegrationTests.Core
             CollectionAssert.AreEqual(outgoing["k1-prep"], prepared.IncomingPayload["k1-prep"]);
             CollectionAssert.AreEqual(outgoing["k2-prep"], prepared.IncomingPayload["k2-prep"]);
         }
+
+        [Test, TestCassandraVersion(2, 2)]
+        public void Prepare_Different_Payloads_With_Same_Id_Test()
+        {
+            const string query = "SELECT key as payload_variant FROM system.local WHERE key = ?";
+            var firstOutgoing = new Dictionary<string, byte[]>
+            {
+                { "payload", Encoding.UTF8.GetBytes("first") }
+            };
+            var secondOutgoing = new Dictionary<string, byte[]>
+            {
+                { "payload", Encoding.UTF8.GetBytes("second") }
+            };
+
+            var first = Session.Prepare(query, firstOutgoing);
+            var second = Session.Prepare(query, secondOutgoing);
+
+            CollectionAssert.AreEqual(first.Id, second.Id);
+            Assert.AreNotSame(first, second);
+            CollectionAssert.AreEqual(firstOutgoing["payload"], first.IncomingPayload["payload"]);
+            CollectionAssert.AreEqual(secondOutgoing["payload"], second.IncomingPayload["payload"]);
+            var repeatedFirst = Session.Prepare(query, firstOutgoing);
+            var repeatedSecond = Session.Prepare(query, secondOutgoing);
+            Assert.AreNotSame(first, repeatedFirst);
+            Assert.AreNotSame(second, repeatedSecond);
+            CollectionAssert.AreEqual(firstOutgoing["payload"], repeatedFirst.IncomingPayload["payload"]);
+            CollectionAssert.AreEqual(secondOutgoing["payload"], repeatedSecond.IncomingPayload["payload"]);
+        }
     }
 }

--- a/src/Cassandra.IntegrationTests/Core/PrepareSimulatorTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PrepareSimulatorTests.cs
@@ -122,7 +122,11 @@ namespace Cassandra.IntegrationTests.Core
                 simulacronCluster.Prime(QueryPrime());
                 var ps = session.Prepare(Query);
                 Assert.NotNull(ps);
+                Assert.AreEqual(3, simulacronCluster.GetQueries(Query, QueryType.Prepare).Count);
                 Assert.AreSame(ps, session.Prepare(Query));
+                Assert.AreEqual(3, simulacronCluster.GetQueries(Query, QueryType.Prepare).Count);
+                Assert.AreSame(ps, cluster.Connect().Prepare(Query));
+                Assert.AreEqual(3, simulacronCluster.GetQueries(Query, QueryType.Prepare).Count);
                 Assert.AreNotSame(ps, session.Prepare("SELECT * FROM system.local WHERE key='local'"));
             }
         }

--- a/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/PreparedStatementsTests.cs
@@ -1187,7 +1187,8 @@ namespace Cassandra.IntegrationTests.Core
             {
                 var session = cluster.Connect();
                 session.Execute($"CREATE TABLE {KeyspaceName}.{tableName} (a int PRIMARY KEY, b int, c int)");
-                var ps = session.Prepare($"SELECT * FROM {KeyspaceName}.{tableName} WHERE a = ?");
+                var query = $"SELECT * FROM {KeyspaceName}.{tableName} WHERE a = ?";
+                var ps = session.Prepare(query);
                 session.ChangeKeyspace(KeyspaceName);
                 session.Execute($"DROP TABLE {tableName}");
                 session.Execute($"CREATE TABLE {tableName} (a int PRIMARY KEY, b int, c int)");
@@ -1196,6 +1197,10 @@ namespace Cassandra.IntegrationTests.Core
                 Assert.IsTrue(ex.Id.SequenceEqual(ps.Id));
                 Assert.IsTrue(ex.Message.Contains("ID mismatch while trying to reprepare"));
                 Assert.IsTrue(ex.Message.Contains($"expected {BitConverter.ToString(ps.Id).Replace("-", "")}"));
+
+                var reprepared = session.Prepare(query);
+                Assert.IsFalse(reprepared.Id.SequenceEqual(ps.Id));
+                Assert.DoesNotThrow(() => session.Execute(reprepared.Bind(1)));
             }
         }
 

--- a/src/Cassandra.Tests/ClusterPrepareTests.cs
+++ b/src/Cassandra.Tests/ClusterPrepareTests.cs
@@ -1,0 +1,579 @@
+//
+//      Copyright (C) DataStax Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Cassandra.Requests;
+using Cassandra.Serialization;
+using Cassandra.SessionManagement;
+using Cassandra.Tests.Connections.TestHelpers;
+
+using Moq;
+
+using NUnit.Framework;
+
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+using CollectionAssert = NUnit.Framework.Legacy.CollectionAssert;
+
+namespace Cassandra.Tests
+{
+    [TestFixture]
+    public class ClusterPrepareTests
+    {
+        [Test]
+        public async Task PrepareAsync_Should_Cache_Prepared_Statement_Per_Cluster()
+        {
+            var serializerManager = new SerializerManager(ProtocolVersion.V4);
+            var handlerMock = new Mock<IPrepareHandler>();
+            handlerMock
+                .Setup(handler => handler.Prepare(
+                    It.IsAny<InternalPrepareRequest>(), It.IsAny<IInternalSession>(),
+                    It.IsAny<IEnumerator<HostShard>>(), It.IsAny<string>()))
+                .Returns<InternalPrepareRequest, IInternalSession, IEnumerator<HostShard>, string>((request, session, _, sessionKeyspace) =>
+                    Task.FromResult(CreatePreparedStatement(
+                        serializerManager,
+                        sessionKeyspace == "ks1" ? (byte)1 : (byte)2,
+                        request.Query,
+                        sessionKeyspace)));
+
+            using (var cluster = CreateCluster(handlerMock.Object))
+            using (var session = CreateSession(cluster, serializerManager, "ks1"))
+            using (var otherSession = CreateSession(cluster, serializerManager, "ks1"))
+            using (var differentKeyspaceSession = CreateSession(cluster, serializerManager, "ks2"))
+            {
+                var first = await PrepareAsync(cluster, session, serializerManager, "SELECT * FROM table1").ConfigureAwait(false);
+                var second = await PrepareAsync(cluster, session, serializerManager, "SELECT * FROM table1").ConfigureAwait(false);
+                var fromOtherSession = await PrepareAsync(
+                    cluster, otherSession, serializerManager, "SELECT * FROM table1").ConfigureAwait(false);
+                var fromDifferentKeyspace = await PrepareAsync(
+                    cluster, differentKeyspaceSession, serializerManager, "SELECT * FROM table1").ConfigureAwait(false);
+
+                Assert.AreSame(first, second);
+                Assert.AreSame(first, fromOtherSession);
+                Assert.AreNotSame(first, fromDifferentKeyspace);
+                handlerMock.Verify(handler => handler.Prepare(
+                    It.IsAny<InternalPrepareRequest>(), It.IsAny<IInternalSession>(),
+                    It.IsAny<IEnumerator<HostShard>>(), It.IsAny<string>()), Times.Exactly(2));
+            }
+        }
+
+        [Test]
+        public async Task PrepareAsync_Should_Normalize_An_Empty_Session_Keyspace()
+        {
+            var serializerManager = new SerializerManager(ProtocolVersion.V4);
+            var handlerMock = new Mock<IPrepareHandler>();
+            handlerMock
+                .Setup(handler => handler.Prepare(
+                    It.IsAny<InternalPrepareRequest>(), It.IsAny<IInternalSession>(),
+                    It.IsAny<IEnumerator<HostShard>>(), It.IsAny<string>()))
+                .Returns<InternalPrepareRequest, IInternalSession, IEnumerator<HostShard>, string>(
+                    (request, _, __, sessionKeyspace) => Task.FromResult(CreatePreparedStatement(
+                        serializerManager, 1, request.Query, sessionKeyspace)));
+
+            using (var cluster = CreateCluster(handlerMock.Object))
+            using (var session = CreateSession(cluster, serializerManager, string.Empty))
+            {
+                var preparedStatement = await PrepareAsync(
+                    cluster, session, serializerManager, "SELECT * FROM system.local").ConfigureAwait(false);
+
+                Assert.IsNull(preparedStatement.Keyspace);
+                handlerMock.Verify(handler => handler.Prepare(
+                    It.IsAny<InternalPrepareRequest>(), It.IsAny<IInternalSession>(),
+                    It.IsAny<IEnumerator<HostShard>>(), null), Times.Once);
+            }
+        }
+
+        [Test]
+        public async Task PrepareAsync_Should_Use_Wire_Effective_Keyspace_In_Cache_Key()
+        {
+            var serializerManager = new SerializerManager(ProtocolVersion.V4);
+            var handlerMock = new Mock<IPrepareHandler>();
+            handlerMock
+                .Setup(handler => handler.Prepare(
+                    It.IsAny<InternalPrepareRequest>(), It.IsAny<IInternalSession>(),
+                    It.IsAny<IEnumerator<HostShard>>(), It.IsAny<string>()))
+                .Returns<InternalPrepareRequest, IInternalSession, IEnumerator<HostShard>, string>((request, session, _, sessionKeyspace) =>
+                    Task.FromResult(CreatePreparedStatement(
+                        serializerManager,
+                        sessionKeyspace == "ks1" ? (byte)1 : (byte)2,
+                        request.Query,
+                        sessionKeyspace)));
+
+            using (var cluster = CreateCluster(handlerMock.Object))
+            using (var firstSession = CreateSession(cluster, serializerManager, "ks1"))
+            using (var secondSession = CreateSession(cluster, serializerManager, "ks2"))
+            {
+                // Protocol v4 does not encode the request keyspace, so the active session keyspace is effective.
+                var first = await PrepareAsync(
+                    cluster, firstSession, serializerManager, "SELECT * FROM table1", "ignored").ConfigureAwait(false);
+                var second = await PrepareAsync(
+                    cluster, secondSession, serializerManager, "SELECT * FROM table1", "ignored").ConfigureAwait(false);
+
+                Assert.AreNotSame(first, second);
+                handlerMock.Verify(handler => handler.Prepare(
+                    It.IsAny<InternalPrepareRequest>(), It.IsAny<IInternalSession>(),
+                    It.IsAny<IEnumerator<HostShard>>(), It.IsAny<string>()), Times.Exactly(2));
+            }
+        }
+
+        [Test]
+        public async Task PrepareAsync_Should_Pin_Session_Keyspace_While_Preparing()
+        {
+            var serializerManager = new SerializerManager(ProtocolVersion.V4);
+            var prepareStarted = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var continuePrepare = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var handlerMock = new Mock<IPrepareHandler>();
+            handlerMock
+                .Setup(handler => handler.Prepare(
+                    It.IsAny<InternalPrepareRequest>(), It.IsAny<IInternalSession>(),
+                    It.IsAny<IEnumerator<HostShard>>(), It.IsAny<string>()))
+                .Returns<InternalPrepareRequest, IInternalSession, IEnumerator<HostShard>, string>(
+                    async (request, _, __, sessionKeyspace) =>
+                    {
+                        prepareStarted.SetResult(sessionKeyspace);
+                        await continuePrepare.Task.ConfigureAwait(false);
+                        return CreatePreparedStatement(
+                            serializerManager, 1, request.Query, sessionKeyspace);
+                    });
+
+            using (var cluster = CreateCluster(handlerMock.Object))
+            using (var session = CreateSession(cluster, serializerManager, "ks1"))
+            {
+                var firstPrepare = PrepareAsync(
+                    cluster, session, serializerManager, "SELECT * FROM table1");
+                Assert.AreEqual("ks1", await prepareStarted.Task.ConfigureAwait(false));
+
+                session.InternalRef.Keyspace = "ks2";
+                continuePrepare.SetResult(true);
+
+                var preparedStatement = await firstPrepare.ConfigureAwait(false);
+                Assert.AreEqual("ks1", preparedStatement.Keyspace);
+
+                session.InternalRef.Keyspace = "ks1";
+                Assert.AreSame(
+                    preparedStatement,
+                    await PrepareAsync(
+                        cluster, session, serializerManager, "SELECT * FROM table1").ConfigureAwait(false));
+                handlerMock.Verify(handler => handler.Prepare(
+                    It.IsAny<InternalPrepareRequest>(), It.IsAny<IInternalSession>(),
+                    It.IsAny<IEnumerator<HostShard>>(), "ks1"), Times.Once);
+            }
+        }
+
+        [Test]
+        public async Task PrepareAsync_Should_Not_Cache_A_Result_For_The_Wrong_Keyspace()
+        {
+            var serializerManager = new SerializerManager(ProtocolVersion.V4);
+            var attempts = 0;
+            var handlerMock = new Mock<IPrepareHandler>();
+            handlerMock
+                .Setup(handler => handler.Prepare(
+                    It.IsAny<InternalPrepareRequest>(), It.IsAny<IInternalSession>(),
+                    It.IsAny<IEnumerator<HostShard>>(), It.IsAny<string>()))
+                .Returns<InternalPrepareRequest, IInternalSession, IEnumerator<HostShard>, string>(
+                    (request, _, __, sessionKeyspace) =>
+                    {
+                        var keyspace = Interlocked.Increment(ref attempts) == 1 ? "ks2" : sessionKeyspace;
+                        return Task.FromResult(CreatePreparedStatement(
+                            serializerManager, (byte)attempts, request.Query, keyspace));
+                    });
+
+            using (var cluster = CreateCluster(handlerMock.Object))
+            using (var session = CreateSession(cluster, serializerManager, "ks1"))
+            {
+                var ex = Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                    await PrepareAsync(
+                        cluster, session, serializerManager, "SELECT * FROM table1").ConfigureAwait(false));
+                Assert.IsTrue(ex.Message.Contains("keyspace changed"));
+
+                var preparedStatement = await PrepareAsync(
+                    cluster, session, serializerManager, "SELECT * FROM table1").ConfigureAwait(false);
+                Assert.AreEqual("ks1", preparedStatement.Keyspace);
+                Assert.AreEqual(2, attempts);
+            }
+        }
+
+        [Test]
+        public async Task PrepareAsync_Should_Coalesce_Concurrent_Prepares()
+        {
+            var serializerManager = new SerializerManager(ProtocolVersion.V4);
+            var preparedStatement = CreatePreparedStatement(serializerManager, 1);
+            var prepareCompletion = new TaskCompletionSource<PreparedStatement>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var handlerMock = new Mock<IPrepareHandler>();
+            handlerMock
+                .Setup(handler => handler.Prepare(
+                    It.IsAny<InternalPrepareRequest>(), It.IsAny<IInternalSession>(),
+                    It.IsAny<IEnumerator<HostShard>>(), It.IsAny<string>()))
+                .Returns(prepareCompletion.Task);
+
+            using (var cluster = CreateCluster(handlerMock.Object))
+            using (var session = CreateSession(cluster, serializerManager, "ks1"))
+            {
+                var prepareTasks = Enumerable.Range(0, 32)
+                    .Select(_ => PrepareAsync(cluster, session, serializerManager, "SELECT * FROM table1"))
+                    .ToArray();
+
+                handlerMock.Verify(handler => handler.Prepare(
+                    It.IsAny<InternalPrepareRequest>(), It.IsAny<IInternalSession>(),
+                    It.IsAny<IEnumerator<HostShard>>(), It.IsAny<string>()), Times.Once);
+                prepareCompletion.SetResult(preparedStatement);
+
+                var results = await Task.WhenAll(prepareTasks).ConfigureAwait(false);
+                Assert.IsTrue(results.All(result => ReferenceEquals(preparedStatement, result)));
+            }
+        }
+
+        [Test]
+        public async Task PrepareAsync_Should_Evict_Failed_Prepare()
+        {
+            var serializerManager = new SerializerManager(ProtocolVersion.V4);
+            var preparedStatement = CreatePreparedStatement(serializerManager, 1);
+            var attempts = 0;
+            var handlerMock = new Mock<IPrepareHandler>();
+            handlerMock
+                .Setup(handler => handler.Prepare(
+                    It.IsAny<InternalPrepareRequest>(), It.IsAny<IInternalSession>(),
+                    It.IsAny<IEnumerator<HostShard>>(), It.IsAny<string>()))
+                .Returns(() => ++attempts == 1
+                    ? Task.FromException<PreparedStatement>(new InvalidOperationException("prepare failed"))
+                    : Task.FromResult(preparedStatement));
+
+            using (var cluster = CreateCluster(handlerMock.Object))
+            using (var session = CreateSession(cluster, serializerManager, "ks1"))
+            {
+                Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                    await PrepareAsync(cluster, session, serializerManager, "SELECT * FROM table1").ConfigureAwait(false));
+
+                Assert.AreSame(
+                    preparedStatement,
+                    await PrepareAsync(cluster, session, serializerManager, "SELECT * FROM table1").ConfigureAwait(false));
+                Assert.AreEqual(2, attempts);
+            }
+        }
+
+        [Test]
+        public async Task PrepareAsync_Should_Reject_Reentrant_Prepare_For_The_Same_Cache_Key()
+        {
+            var serializerManager = new SerializerManager(ProtocolVersion.V4);
+            Cluster cluster = null;
+            Session session = null;
+            var handlerMock = new Mock<IPrepareHandler>();
+            handlerMock
+                .Setup(handler => handler.Prepare(
+                    It.IsAny<InternalPrepareRequest>(), It.IsAny<IInternalSession>(),
+                    It.IsAny<IEnumerator<HostShard>>(), It.IsAny<string>()))
+                .Returns(() => PrepareAsync(
+                    cluster, session, serializerManager, "SELECT * FROM table1"));
+
+            using (cluster = CreateCluster(handlerMock.Object))
+            using (session = CreateSession(cluster, serializerManager, "ks1"))
+            {
+                var prepareTask = PrepareAsync(
+                    cluster, session, serializerManager, "SELECT * FROM table1");
+                var completedTask = await Task.WhenAny(
+                    prepareTask, Task.Delay(TimeSpan.FromSeconds(2))).ConfigureAwait(false);
+                Assert.AreSame(prepareTask, completedTask, "Reentrant prepare should not deadlock");
+
+                var ex = Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                    await prepareTask.ConfigureAwait(false));
+                Assert.IsTrue(ex.Message.Contains("recursively prepare"));
+                handlerMock.Verify(handler => handler.Prepare(
+                    It.IsAny<InternalPrepareRequest>(), It.IsAny<IInternalSession>(),
+                    It.IsAny<IEnumerator<HostShard>>(), It.IsAny<string>()), Times.Once);
+            }
+        }
+
+        [Test]
+        public async Task PrepareAsync_Should_Not_Retain_Custom_Payload_Entries()
+        {
+            var serializerManager = new SerializerManager(ProtocolVersion.V5);
+            var attempts = 0;
+            var handlerMock = new Mock<IPrepareHandler>();
+            handlerMock
+                .Setup(handler => handler.Prepare(
+                    It.IsAny<InternalPrepareRequest>(), It.IsAny<IInternalSession>(),
+                    It.IsAny<IEnumerator<HostShard>>(), It.IsAny<string>()))
+                .Returns<InternalPrepareRequest, IInternalSession, IEnumerator<HostShard>, string>((request, session, _, sessionKeyspace) =>
+                {
+                    Interlocked.Increment(ref attempts);
+                    return Task.FromResult(CreatePreparedStatement(
+                        serializerManager,
+                        request.Keyspace == "ks2" ? (byte)2 : (byte)1,
+                        request.Query,
+                        request.Keyspace ?? sessionKeyspace,
+                        request.Payload));
+                });
+
+            using (var cluster = CreateCluster(handlerMock.Object))
+            using (var session = CreateSession(cluster, serializerManager, "ks1"))
+            {
+                var payload = new Dictionary<string, byte[]> { { "payload", new byte[] { 1, 2, 3 } } };
+                var equivalentPayload = new Dictionary<string, byte[]> { { "payload", new byte[] { 1, 2, 3 } } };
+                var differentPayload = new Dictionary<string, byte[]> { { "payload", new byte[] { 4, 5, 6 } } };
+
+                var first = await PrepareAsync(
+                    cluster, session, serializerManager, "SELECT * FROM table1", "ks1", payload).ConfigureAwait(false);
+                var repeated = await PrepareAsync(
+                    cluster, session, serializerManager, "SELECT * FROM table1", "ks1", equivalentPayload).ConfigureAwait(false);
+                var differentKeyspace = await PrepareAsync(
+                    cluster, session, serializerManager, "SELECT * FROM table1", "ks2", payload).ConfigureAwait(false);
+                var differentCustomPayload = await PrepareAsync(
+                    cluster, session, serializerManager, "SELECT * FROM table1", "ks1", differentPayload).ConfigureAwait(false);
+
+                Assert.AreNotSame(first, repeated);
+                Assert.AreNotSame(first, differentKeyspace);
+                Assert.AreNotSame(first, differentCustomPayload);
+                CollectionAssert.AreEqual(differentPayload["payload"], differentCustomPayload.IncomingPayload["payload"]);
+                Assert.AreEqual(4, attempts);
+            }
+        }
+
+        [Test]
+        public async Task PrepareAsync_Should_Not_Coalesce_Custom_Payload_While_In_Flight()
+        {
+            var serializerManager = new SerializerManager(ProtocolVersion.V5);
+            var attempts = 0;
+            var firstPrepareCompletion =
+                new TaskCompletionSource<PreparedStatement>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var handlerMock = new Mock<IPrepareHandler>();
+            handlerMock
+                .Setup(handler => handler.Prepare(
+                    It.IsAny<InternalPrepareRequest>(), It.IsAny<IInternalSession>(),
+                    It.IsAny<IEnumerator<HostShard>>(), It.IsAny<string>()))
+                .Returns(() => Interlocked.Increment(ref attempts) == 1
+                    ? firstPrepareCompletion.Task
+                    : Task.FromResult(CreatePreparedStatement(serializerManager, 2)));
+
+            using (var cluster = CreateCluster(handlerMock.Object))
+            using (var session = CreateSession(cluster, serializerManager, "ks1"))
+            {
+                var firstPayload = new Dictionary<string, byte[]> { { "payload", new byte[] { 1, 2, 3 } } };
+                var equivalentPayload = new Dictionary<string, byte[]> { { "payload", new byte[] { 1, 2, 3 } } };
+                var first = PrepareAsync(
+                    cluster, session, serializerManager, "SELECT * FROM table1", "ks1", firstPayload);
+                var concurrent = PrepareAsync(
+                    cluster, session, serializerManager, "SELECT * FROM table1", "ks1", equivalentPayload);
+
+                Assert.AreEqual(2, attempts);
+                var firstPreparedStatement = CreatePreparedStatement(serializerManager, 1);
+                firstPrepareCompletion.SetResult(firstPreparedStatement);
+                Assert.AreSame(firstPreparedStatement, await first.ConfigureAwait(false));
+                Assert.AreNotSame(firstPreparedStatement, await concurrent.ConfigureAwait(false));
+                Assert.AreEqual(2, attempts);
+            }
+        }
+
+        [Test]
+        public async Task PrepareAsync_Should_Prepare_Again_After_Invalidation()
+        {
+            var serializerManager = new SerializerManager(ProtocolVersion.V4);
+            var attempts = 0;
+            var handlerMock = new Mock<IPrepareHandler>();
+            handlerMock
+                .Setup(handler => handler.Prepare(
+                    It.IsAny<InternalPrepareRequest>(), It.IsAny<IInternalSession>(),
+                    It.IsAny<IEnumerator<HostShard>>(), It.IsAny<string>()))
+                .Returns<InternalPrepareRequest, IInternalSession, IEnumerator<HostShard>, string>((request, session, _, sessionKeyspace) =>
+                    Task.FromResult(CreatePreparedStatement(
+                        serializerManager,
+                        (byte)Interlocked.Increment(ref attempts),
+                        request.Query,
+                        sessionKeyspace)));
+
+            using (var cluster = CreateCluster(handlerMock.Object))
+            using (var session = CreateSession(cluster, serializerManager, "ks1"))
+            {
+                var first = await PrepareAsync(
+                    cluster, session, serializerManager, "SELECT * FROM table1").ConfigureAwait(false);
+
+                cluster.InternalRef.InvalidatePreparedStatement(first.Id);
+
+                var second = await PrepareAsync(
+                    cluster, session, serializerManager, "SELECT * FROM table1").ConfigureAwait(false);
+                Assert.AreNotSame(first, second);
+                CollectionAssert.AreNotEqual(first.Id, second.Id);
+                Assert.AreEqual(2, attempts);
+            }
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public async Task PrepareAsync_Should_Track_Unrelated_InFlight_Prepare_Across_Invalidation(
+            bool customPayload)
+        {
+            var serializerManager = new SerializerManager(ProtocolVersion.V5);
+            var secondPrepareStarted =
+                new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var secondPrepareCompletion =
+                new TaskCompletionSource<PreparedStatement>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var handlerMock = new Mock<IPrepareHandler>();
+            handlerMock
+                .Setup(handler => handler.Prepare(
+                    It.IsAny<InternalPrepareRequest>(), It.IsAny<IInternalSession>(),
+                    It.IsAny<IEnumerator<HostShard>>(), It.IsAny<string>()))
+                .Returns<InternalPrepareRequest, IInternalSession, IEnumerator<HostShard>, string>(
+                    (request, _, __, sessionKeyspace) =>
+                    {
+                        if (request.Query == "SELECT * FROM table2")
+                        {
+                            secondPrepareStarted.TrySetResult(true);
+                            return secondPrepareCompletion.Task;
+                        }
+                        return Task.FromResult(CreatePreparedStatement(
+                            serializerManager, 1, request.Query, request.Keyspace ?? sessionKeyspace));
+                    });
+
+            using (var cluster = CreateCluster(handlerMock.Object))
+            using (var session = CreateSession(cluster, serializerManager, "ks1"))
+            {
+                var first = await PrepareAsync(
+                    cluster, session, serializerManager, "SELECT * FROM table1").ConfigureAwait(false);
+                var payload = customPayload
+                    ? new Dictionary<string, byte[]> { { "payload", new byte[] { 1 } } }
+                    : null;
+                var secondTask = PrepareAsync(
+                    cluster, session, serializerManager, "SELECT * FROM table2", "ks1", payload);
+                await secondPrepareStarted.Task.ConfigureAwait(false);
+
+                cluster.InternalRef.InvalidatePreparedStatement(first.Id);
+                var second = CreatePreparedStatement(
+                    serializerManager, 2, "SELECT * FROM table2", "ks1", payload);
+                secondPrepareCompletion.SetResult(second);
+
+                Assert.AreSame(second, await secondTask.ConfigureAwait(false));
+                Assert.IsTrue(cluster.InternalRef.PreparedQueries.TryGetValue(second.Id, out var tracked));
+                Assert.AreSame(second, tracked);
+            }
+        }
+
+        [Test]
+        public async Task PrepareAsync_Should_Not_Cache_An_InFlight_Result_Invalidated_While_Preparing()
+        {
+            var serializerManager = new SerializerManager(ProtocolVersion.V4);
+            var attempts = 0;
+            var secondPrepareCompletion =
+                new TaskCompletionSource<PreparedStatement>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var handlerMock = new Mock<IPrepareHandler>();
+            handlerMock
+                .Setup(handler => handler.Prepare(
+                    It.IsAny<InternalPrepareRequest>(), It.IsAny<IInternalSession>(),
+                    It.IsAny<IEnumerator<HostShard>>(), It.IsAny<string>()))
+                .Returns<InternalPrepareRequest, IInternalSession, IEnumerator<HostShard>, string>(
+                    (request, _, __, sessionKeyspace) =>
+                    {
+                        var attempt = Interlocked.Increment(ref attempts);
+                        if (attempt == 2)
+                        {
+                            return secondPrepareCompletion.Task;
+                        }
+                        return Task.FromResult(CreatePreparedStatement(
+                            serializerManager, (byte)attempt, request.Query, sessionKeyspace));
+                    });
+
+            using (var cluster = CreateCluster(handlerMock.Object))
+            using (var session = CreateSession(cluster, serializerManager, "ks1"))
+            {
+                var first = await PrepareAsync(
+                    cluster, session, serializerManager, "SELECT * FROM table1").ConfigureAwait(false);
+                cluster.InternalRef.InvalidatePreparedStatement(first.Id);
+
+                var inFlight = PrepareAsync(
+                    cluster, session, serializerManager, "SELECT * FROM table1");
+                Assert.AreEqual(2, attempts);
+                cluster.InternalRef.InvalidatePreparedStatement(first.Id);
+                secondPrepareCompletion.SetResult(CreatePreparedStatement(
+                    serializerManager, 1, "SELECT * FROM table1", "ks1"));
+                await inFlight.ConfigureAwait(false);
+
+                var replacement = await PrepareAsync(
+                    cluster, session, serializerManager, "SELECT * FROM table1").ConfigureAwait(false);
+                Assert.AreEqual(3, attempts);
+                CollectionAssert.AreEqual(new byte[] { 3 }, replacement.Id);
+            }
+        }
+
+        private static Cluster CreateCluster(IPrepareHandler prepareHandler)
+        {
+            var loadBalancingPolicy = new Mock<ILoadBalancingPolicy>();
+            loadBalancingPolicy
+                .Setup(policy => policy.NewQueryPlan(It.IsAny<string>(), It.IsAny<IStatement>()))
+                .Returns(Enumerable.Empty<HostShard>());
+
+            var prepareHandlerFactory = new Mock<IPrepareHandlerFactory>();
+            prepareHandlerFactory
+                .Setup(factory => factory.CreatePrepareHandler(
+                    It.IsAny<ISerializerManager>(),
+                    It.IsAny<IInternalCluster>(),
+                    It.IsAny<IInternalSession>(),
+                    It.IsAny<InternalPrepareRequest>()))
+                .Returns(prepareHandler);
+
+            var configuration = new TestConfigurationBuilder
+            {
+                ControlConnectionFactory = new FakeControlConnectionFactory(),
+                PrepareHandlerFactory = prepareHandlerFactory.Object,
+                Policies = new Cassandra.Policies(
+                    loadBalancingPolicy.Object,
+                    new ConstantReconnectionPolicy(100),
+                    new DefaultRetryPolicy())
+            }.Build();
+            var initializer = Mock.Of<IInitializer>();
+            Mock.Get(initializer).Setup(value => value.ContactPoints).Returns(new List<IPEndPoint>());
+            Mock.Get(initializer).Setup(value => value.GetConfiguration()).Returns(configuration);
+
+            return Cluster.BuildFrom(initializer, new List<string> { "127.0.0.1" }, configuration);
+        }
+
+        private static Session CreateSession(
+            Cluster cluster, ISerializerManager serializerManager, string keyspace)
+        {
+            return new Session(cluster, cluster.Configuration, keyspace, serializerManager, "test-session");
+        }
+
+        private static Task<PreparedStatement> PrepareAsync(
+            Cluster cluster,
+            IInternalSession session,
+            ISerializerManager serializerManager,
+            string cqlQuery,
+            string keyspace = null,
+            IDictionary<string, byte[]> customPayload = null)
+        {
+            return cluster.InternalRef.Prepare(
+                session,
+                serializerManager,
+                new InternalPrepareRequest(serializerManager.GetCurrentSerializer(), cqlQuery, keyspace, customPayload));
+        }
+
+        private static PreparedStatement CreatePreparedStatement(
+            ISerializerManager serializerManager,
+            byte id,
+            string cqlQuery = "SELECT * FROM table1",
+            string keyspace = "ks1",
+            IDictionary<string, byte[]> incomingPayload = null)
+        {
+            return new PreparedStatement(
+                null, new[] { id }, null, cqlQuery, keyspace, serializerManager, false)
+            {
+                IncomingPayload = incomingPayload
+            };
+        }
+    }
+}

--- a/src/Cassandra.Tests/ConnectionTests.cs
+++ b/src/Cassandra.Tests/ConnectionTests.cs
@@ -339,6 +339,28 @@ namespace Cassandra.Tests
             Assert.AreEqual(3, responses.Count);
         }
 
+        [Test]
+        public void ReadParse_Should_Update_Connection_Keyspace_From_SetKeyspace_Response()
+        {
+            var serializer = new SerializerManager(ProtocolVersion.V4);
+            var connectionMock = GetConnectionMock(null, serializer);
+            connectionMock
+                .Setup(c => c.RemoveFromPending(It.IsAny<short>()))
+                .Returns(() => OperationStateExtensions.CreateMock((_, __) => { }));
+            var buffer = new byte[]
+            {
+                // v4 response header: stream 1, RESULT opcode, body length 9
+                0x84, 0, 0, 1, ResultResponse.OpCode, 0, 0, 0, 9,
+                // SET_KEYSPACE result followed by the string "ks1"
+                0, 0, 0, 3, 0, 3, (byte)'k', (byte)'s', (byte)'1'
+            };
+
+            connectionMock.Object.ReadParse(buffer, buffer.Length);
+
+            TestHelper.WaitUntil(() => connectionMock.Object.Keyspace == "ks1");
+            Assert.AreEqual("ks1", connectionMock.Object.Keyspace);
+        }
+
         /// <summary>
         /// Gets a buffer containing 8 bytes for header and 4 bytes for the body.
         /// For result + void response message  (protocol v2)

--- a/src/Cassandra.Tests/IOUnitTests.cs
+++ b/src/Cassandra.Tests/IOUnitTests.cs
@@ -125,6 +125,27 @@ namespace Cassandra.Tests
             Assert.AreEqual(0, clientCallbackCounter);
         }
 
+        [TestCase(false)]
+        [TestCase(true)]
+        public void OperationState_Cancel_Should_Invoke_Cancellation_Handler_Once(bool cancelFirst)
+        {
+            var cancellationCount = 0;
+            var state = OperationStateExtensions.CreateMock((_, __) => { });
+
+            if (cancelFirst)
+            {
+                state.Cancel();
+            }
+            state.SetCancellationHandler(() => Interlocked.Increment(ref cancellationCount));
+            if (!cancelFirst)
+            {
+                state.Cancel();
+            }
+            state.Cancel();
+
+            Assert.AreEqual(1, cancellationCount);
+        }
+
         [Test]
         public void BeBinaryWriter_Close_Sets_Frame_Body_Length()
         {

--- a/src/Cassandra.Tests/Requests/PrepareHandlerTests.cs
+++ b/src/Cassandra.Tests/Requests/PrepareHandlerTests.cs
@@ -61,12 +61,13 @@ namespace Cassandra.Tests.Requests
                         new AtomicMonotonicTimestampGenerator(),
                         null);
                 });
+            mockResult.Session.Keyspace = "ks1";
             // mock connection send
             mockResult.ConnectionFactory.OnCreate += connection =>
             {
                 Mock.Get(connection)
-                    .Setup(c => c.Send(It.IsAny<IRequest>()))
-                    .Returns<IRequest>(async req =>
+                    .Setup(c => c.SendWithKeyspace(It.IsAny<IRequest>(), It.IsAny<string>()))
+                    .Returns<IRequest, string>(async (req, _) =>
                     {
                         mockResult.SendResults.Enqueue(new ConnectionSendResult { Connection = connection, Request = req });
                         await Task.Delay(1).ConfigureAwait(false);
@@ -90,7 +91,8 @@ namespace Cassandra.Tests.Requests
             await mockResult.PrepareHandler.Prepare(
                 request,
                 mockResult.Session,
-                queryPlan.GetEnumerator()).ConfigureAwait(false);
+                queryPlan.GetEnumerator(),
+                mockResult.Session.Keyspace).ConfigureAwait(false);
 
             var results = mockResult.SendResults.ToArray();
 
@@ -107,7 +109,7 @@ namespace Cassandra.Tests.Requests
             Assert.AreEqual(2, poolConnections.Count);
             foreach (var pool in poolConnections)
             {
-                Mock.Get(pool.Single()).Verify(c => c.Send(request), Times.Once);
+                Mock.Get(pool.Single()).Verify(c => c.SendWithKeyspace(request, "ks1"), Times.Once);
             }
         }
 
@@ -136,8 +138,8 @@ namespace Cassandra.Tests.Requests
             mockResult.ConnectionFactory.OnCreate += connection =>
             {
                 Mock.Get(connection)
-                    .Setup(c => c.Send(It.IsAny<IRequest>()))
-                    .Returns<IRequest>(async req =>
+                    .Setup(c => c.SendWithKeyspace(It.IsAny<IRequest>(), It.IsAny<string>()))
+                    .Returns<IRequest, string>(async (req, _) =>
                     {
                         mockResult.SendResults.Enqueue(new ConnectionSendResult { Connection = connection, Request = req });
                         await Task.Delay(1).ConfigureAwait(false);
@@ -162,7 +164,8 @@ namespace Cassandra.Tests.Requests
             await mockResult.PrepareHandler.Prepare(
                 request,
                 mockResult.Session,
-                queryPlan.GetEnumerator()).ConfigureAwait(false);
+                queryPlan.GetEnumerator(),
+                mockResult.Session.Keyspace).ConfigureAwait(false);
 
             var results = mockResult.SendResults.ToArray();
 
@@ -179,7 +182,7 @@ namespace Cassandra.Tests.Requests
             Assert.AreEqual(2, poolConnections.Count);
             foreach (var pool in poolConnections)
             {
-                Mock.Get(pool.Single()).Verify(c => c.Send(request), Times.Once);
+                Mock.Get(pool.Single()).Verify(c => c.SendWithKeyspace(request, It.IsAny<string>()), Times.Once);
             }
         }
 
@@ -208,8 +211,8 @@ namespace Cassandra.Tests.Requests
             mockResult.ConnectionFactory.OnCreate += connection =>
             {
                 Mock.Get(connection)
-                    .Setup(c => c.Send(It.IsAny<IRequest>()))
-                    .Returns<IRequest>(async req =>
+                    .Setup(c => c.SendWithKeyspace(It.IsAny<IRequest>(), It.IsAny<string>()))
+                    .Returns<IRequest, string>(async (req, _) =>
                     {
                         mockResult.SendResults.Enqueue(new ConnectionSendResult { Connection = connection, Request = req });
                         await Task.Delay(1).ConfigureAwait(false);
@@ -235,7 +238,8 @@ namespace Cassandra.Tests.Requests
             await mockResult.PrepareHandler.Prepare(
                 request,
                 mockResult.Session,
-                queryPlan.GetEnumerator()).ConfigureAwait(false);
+                queryPlan.GetEnumerator(),
+                mockResult.Session.Keyspace).ConfigureAwait(false);
 
             var results = mockResult.SendResults.ToArray();
 
@@ -253,7 +257,7 @@ namespace Cassandra.Tests.Requests
             Assert.AreEqual(3, poolConnections.Count);
             foreach (var pool in poolConnections)
             {
-                Mock.Get(pool.Single()).Verify(c => c.Send(request), Times.Once);
+                Mock.Get(pool.Single()).Verify(c => c.SendWithKeyspace(request, It.IsAny<string>()), Times.Once);
             }
         }
 
@@ -282,8 +286,8 @@ namespace Cassandra.Tests.Requests
             mockResult.ConnectionFactory.OnCreate += connection =>
             {
                 Mock.Get(connection)
-                    .Setup(c => c.Send(It.IsAny<IRequest>()))
-                    .Returns<IRequest>(async req =>
+                    .Setup(c => c.SendWithKeyspace(It.IsAny<IRequest>(), It.IsAny<string>()))
+                    .Returns<IRequest, string>(async (req, _) =>
                     {
                         mockResult.SendResults.Enqueue(new ConnectionSendResult { Connection = connection, Request = req });
                         await Task.Delay(1).ConfigureAwait(false);
@@ -307,7 +311,8 @@ namespace Cassandra.Tests.Requests
             await mockResult.PrepareHandler.Prepare(
                 request,
                 mockResult.Session,
-                queryPlan.GetEnumerator()).ConfigureAwait(false);
+                queryPlan.GetEnumerator(),
+                mockResult.Session.Keyspace).ConfigureAwait(false);
 
             var results = mockResult.SendResults.ToArray();
 
@@ -325,7 +330,7 @@ namespace Cassandra.Tests.Requests
             Assert.AreEqual(3, poolConnections.Count);
             foreach (var pool in poolConnections)
             {
-                Mock.Get(pool.Single()).Verify(c => c.Send(request), Times.Once);
+                Mock.Get(pool.Single()).Verify(c => c.SendWithKeyspace(request, It.IsAny<string>()), Times.Once);
             }
         }
 
@@ -354,8 +359,8 @@ namespace Cassandra.Tests.Requests
             mockResult.ConnectionFactory.OnCreate += connection =>
             {
                 Mock.Get(connection)
-                    .Setup(c => c.Send(It.IsAny<IRequest>()))
-                    .Returns<IRequest>(async req =>
+                    .Setup(c => c.SendWithKeyspace(It.IsAny<IRequest>(), It.IsAny<string>()))
+                    .Returns<IRequest, string>(async (req, _) =>
                     {
                         mockResult.SendResults.Enqueue(new ConnectionSendResult { Connection = connection, Request = req });
                         await Task.Delay(1).ConfigureAwait(false);
@@ -379,7 +384,8 @@ namespace Cassandra.Tests.Requests
             await mockResult.PrepareHandler.Prepare(
                 request,
                 mockResult.Session,
-                queryPlan.GetEnumerator()).ConfigureAwait(false);
+                queryPlan.GetEnumerator(),
+                mockResult.Session.Keyspace).ConfigureAwait(false);
 
             var results = mockResult.SendResults.ToArray();
 
@@ -397,7 +403,7 @@ namespace Cassandra.Tests.Requests
             Assert.AreEqual(3, poolConnections.Count);
             foreach (var pool in poolConnections)
             {
-                Mock.Get(pool.Single()).Verify(c => c.Send(request), Times.Once);
+                Mock.Get(pool.Single()).Verify(c => c.SendWithKeyspace(request, It.IsAny<string>()), Times.Once);
             }
         }
 
@@ -427,8 +433,8 @@ namespace Cassandra.Tests.Requests
             mockResult.ConnectionFactory.OnCreate += connection =>
             {
                 Mock.Get(connection)
-                    .Setup(c => c.Send(It.IsAny<IRequest>()))
-                    .Returns<IRequest>(async req =>
+                    .Setup(c => c.SendWithKeyspace(It.IsAny<IRequest>(), It.IsAny<string>()))
+                    .Returns<IRequest, string>(async (req, _) =>
                     {
                         mockResult.SendResults.Enqueue(new ConnectionSendResult { Connection = connection, Request = req });
                         await Task.Delay(1).ConfigureAwait(false);
@@ -452,7 +458,8 @@ namespace Cassandra.Tests.Requests
             await mockResult.PrepareHandler.Prepare(
                 request,
                 mockResult.Session,
-                queryPlan.GetEnumerator()).ConfigureAwait(false);
+                queryPlan.GetEnumerator(),
+                mockResult.Session.Keyspace).ConfigureAwait(false);
 
             var results = mockResult.SendResults.ToArray();
 
@@ -474,7 +481,7 @@ namespace Cassandra.Tests.Requests
             Assert.AreEqual(1, poolConnections.Count);
             foreach (var pool in poolConnections)
             {
-                Mock.Get(pool.Single()).Verify(c => c.Send(request), Times.Once);
+                Mock.Get(pool.Single()).Verify(c => c.SendWithKeyspace(request, It.IsAny<string>()), Times.Once);
             }
         }
 

--- a/src/Cassandra/Cluster.cs
+++ b/src/Cassandra/Cluster.cs
@@ -44,8 +44,17 @@ namespace Cassandra
 
         private static ProtocolVersion _maxProtocolVersion = ProtocolVersion.MaxSupported;
         internal static readonly Logger Logger = new Logger(typeof(Cluster));
+        private static readonly IEqualityComparer<byte[]> PreparedStatementIdComparer = new ByteArrayComparer();
         private readonly CopyOnWriteList<IInternalSession> _connectedSessions = new CopyOnWriteList<IInternalSession>();
         private readonly IControlConnection _controlConnection;
+        private readonly ConcurrentDictionary<PreparedStatementCacheKey, PreparedStatementCacheEntry> _preparedStatementCache =
+            new ConcurrentDictionary<PreparedStatementCacheKey, PreparedStatementCacheEntry>();
+        private readonly AsyncLocal<PreparedStatementPreparationScope> _preparedStatementPreparationScope =
+            new AsyncLocal<PreparedStatementPreparationScope>();
+        private readonly object _preparedStatementTrackingLock = new object();
+        private readonly HashSet<PreparedStatementPreparation> _activePreparedStatementPreparations =
+            new HashSet<PreparedStatementPreparation>();
+        private long _preparedStatementCacheGeneration;
         private volatile bool _initialized;
         private volatile Exception _initException;
         private readonly SemaphoreSlim _initLock = new SemaphoreSlim(1, 1);
@@ -77,7 +86,7 @@ namespace Cassandra
 
         /// <inheritdoc />
         ConcurrentDictionary<byte[], PreparedStatement> IInternalCluster.PreparedQueries { get; }
-            = new ConcurrentDictionary<byte[], PreparedStatement>(new ByteArrayComparer());
+            = new ConcurrentDictionary<byte[], PreparedStatement>(Cluster.PreparedStatementIdComparer);
 
         /// <summary>
         ///  Build a new cluster based on the provided initializer. <p> Note that for
@@ -554,6 +563,7 @@ namespace Cassandra
         {
             if (!_initialized)
             {
+                _preparedStatementCache.Clear();
                 _metadata.ShutDown(timeoutMs);
                 _controlConnection.Dispose();
                 await _protocolEventDebouncer.ShutdownAsync().ConfigureAwait(false);
@@ -581,6 +591,7 @@ namespace Cassandra
                 }
                 throw;
             }
+            _preparedStatementCache.Clear();
             _metadata.ShutDown(timeoutMs);
             _controlConnection.Dispose();
             await _protocolEventDebouncer.ShutdownAsync().ConfigureAwait(false);
@@ -625,18 +636,188 @@ namespace Cassandra
         async Task<PreparedStatement> IInternalCluster.Prepare(
             IInternalSession session, ISerializerManager serializerManager, InternalPrepareRequest request)
         {
-            var lbp = session.Cluster.Configuration.DefaultRequestOptions.LoadBalancingPolicy;
-            var handler = InternalRef.Configuration.PrepareHandlerFactory.CreatePrepareHandler(serializerManager, this, session, request);
-            var ps = await handler.Prepare(request, session, lbp.NewQueryPlan(session.Keyspace, null).GetEnumerator()).ConfigureAwait(false);
-            var psAdded = InternalRef.PreparedQueries.GetOrAdd(ps.Id, ps);
-            if (ps != psAdded)
+            var serializer = serializerManager.GetCurrentSerializer();
+            var sessionKeyspace = string.IsNullOrEmpty(session.Keyspace) ? null : session.Keyspace;
+            var requestKeyspace = serializer.ProtocolVersion.SupportsKeyspaceInRequest()
+                ? request.Keyspace
+                : null;
+            var effectiveKeyspace = requestKeyspace ?? sessionKeyspace;
+            var cacheKey = new PreparedStatementCacheKey(
+                request.Query, effectiveKeyspace, request.Payload);
+
+            if (PreparedStatementPreparationScope.Contains(_preparedStatementPreparationScope.Value, cacheKey))
             {
-                PrepareHandler.Logger.Warning("Re-preparing already prepared query is generally an anti-pattern and will likely " +
-                               "affect performance. Consider preparing the statement only once. Query='{0}'", ps.Cql);
-                ps = psAdded;
+                throw new InvalidOperationException(
+                    "A prepare callback can not recursively prepare the same query, keyspace, and custom payload.");
             }
 
-            return ps;
+            if (request.Payload != null)
+            {
+                return await PrepareWithScopeAsync(
+                    cacheKey,
+                    session,
+                    serializerManager,
+                    request,
+                    sessionKeyspace,
+                    effectiveKeyspace).ConfigureAwait(false);
+            }
+
+            var cacheGeneration = Volatile.Read(ref _preparedStatementCacheGeneration);
+            var prepareEntry = _preparedStatementCache.GetOrAdd(
+                cacheKey,
+                key => new PreparedStatementCacheEntry(
+                    cacheGeneration,
+                    () => PrepareWithScopeAsync(
+                        key,
+                        session,
+                        serializerManager,
+                        new InternalPrepareRequest(
+                            serializer, request.Query, requestKeyspace, key.GetCustomPayload()),
+                        sessionKeyspace,
+                        effectiveKeyspace)));
+
+            try
+            {
+                var preparedStatement = await prepareEntry.Task.Value.ConfigureAwait(false);
+                if (Volatile.Read(ref _preparedStatementCacheGeneration) != prepareEntry.Generation)
+                {
+                    RemovePreparedStatementCacheEntry(cacheKey, prepareEntry);
+                }
+                return preparedStatement;
+            }
+            catch
+            {
+                // A failed prepare must not poison the cache. Remove only this exact value: another caller may
+                // have already removed it and started a new attempt.
+                RemovePreparedStatementCacheEntry(cacheKey, prepareEntry);
+                throw;
+            }
+        }
+
+        private async Task<PreparedStatement> PrepareWithScopeAsync(
+            PreparedStatementCacheKey cacheKey,
+            IInternalSession session,
+            ISerializerManager serializerManager,
+            InternalPrepareRequest request,
+            string sessionKeyspace,
+            string effectiveKeyspace)
+        {
+            var previousScope = _preparedStatementPreparationScope.Value;
+            var currentScope = new PreparedStatementPreparationScope(cacheKey, previousScope);
+            _preparedStatementPreparationScope.Value = currentScope;
+            try
+            {
+                return await PrepareAsync(
+                    session,
+                    serializerManager,
+                    request,
+                    sessionKeyspace,
+                    effectiveKeyspace).ConfigureAwait(false);
+            }
+            finally
+            {
+                currentScope.Deactivate();
+                _preparedStatementPreparationScope.Value = previousScope;
+            }
+        }
+
+        private async Task<PreparedStatement> PrepareAsync(
+            IInternalSession session,
+            ISerializerManager serializerManager,
+            InternalPrepareRequest request,
+            string sessionKeyspace,
+            string effectiveKeyspace)
+        {
+            var preparation = new PreparedStatementPreparation();
+            lock (_preparedStatementTrackingLock)
+            {
+                _activePreparedStatementPreparations.Add(preparation);
+            }
+
+            var lbp = session.Cluster.Configuration.DefaultRequestOptions.LoadBalancingPolicy;
+            var handler = InternalRef.Configuration.PrepareHandlerFactory.CreatePrepareHandler(serializerManager, this, session, request);
+            try
+            {
+                var ps = await handler.Prepare(
+                    request,
+                    session,
+                    lbp.NewQueryPlan(sessionKeyspace, null).GetEnumerator(),
+                    sessionKeyspace).ConfigureAwait(false);
+                if (!string.Equals(ps.Keyspace, effectiveKeyspace, StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException(
+                        $"The session keyspace changed while preparing the statement. Expected '{effectiveKeyspace}', " +
+                        $"but the statement was prepared with '{ps.Keyspace}'. Retry the prepare operation.");
+                }
+
+                // Registration and invalidation are serialized so invalidating one statement can not suppress
+                // prepare-on-up tracking for unrelated statements that happen to be preparing concurrently.
+                lock (_preparedStatementTrackingLock)
+                {
+                    if (!preparation.WasInvalidated(ps.Id))
+                    {
+                        // Track one instance per server-side ID. Different custom payloads can legitimately
+                        // produce different response payloads even when the server returns the same ID.
+                        InternalRef.PreparedQueries.TryAdd(ps.Id, ps);
+                    }
+                    _activePreparedStatementPreparations.Remove(preparation);
+                }
+                return ps;
+            }
+            catch
+            {
+                lock (_preparedStatementTrackingLock)
+                {
+                    _activePreparedStatementPreparations.Remove(preparation);
+                }
+                throw;
+            }
+        }
+
+        private void RemovePreparedStatementCacheEntry(
+            PreparedStatementCacheKey cacheKey, PreparedStatementCacheEntry prepareEntry)
+        {
+            ((ICollection<KeyValuePair<PreparedStatementCacheKey, PreparedStatementCacheEntry>>)_preparedStatementCache)
+                .Remove(new KeyValuePair<PreparedStatementCacheKey, PreparedStatementCacheEntry>(cacheKey, prepareEntry));
+        }
+
+        /// <inheritdoc />
+        void IInternalCluster.InvalidatePreparedStatement(byte[] id)
+        {
+            var generation = Interlocked.Increment(ref _preparedStatementCacheGeneration);
+            lock (_preparedStatementTrackingLock)
+            {
+                foreach (var preparation in _activePreparedStatementPreparations)
+                {
+                    preparation.Invalidate(id);
+                }
+                InternalRef.PreparedQueries.TryRemove(id, out _);
+            }
+
+            foreach (var entry in _preparedStatementCache)
+            {
+                if (!entry.Value.Task.IsValueCreated)
+                {
+                    ((ICollection<KeyValuePair<PreparedStatementCacheKey, PreparedStatementCacheEntry>>)_preparedStatementCache)
+                        .Remove(entry);
+                    continue;
+                }
+
+                var task = entry.Value.Task.Value;
+                if (task.Status != TaskStatus.RanToCompletion)
+                {
+                    continue;
+                }
+
+                if (Cluster.PreparedStatementIdComparer.Equals(task.Result.Id, id))
+                {
+                    ((ICollection<KeyValuePair<PreparedStatementCacheKey, PreparedStatementCacheEntry>>)_preparedStatementCache)
+                        .Remove(entry);
+                    continue;
+                }
+
+                entry.Value.UpdateGeneration(generation);
+            }
         }
 
         /// <inheritdoc />
@@ -694,6 +875,179 @@ namespace Cassandra
                         host.Address,
                         ex);
                 }
+            }
+        }
+
+        private sealed class PreparedStatementPreparationScope
+        {
+            private int _active = 1;
+
+            public PreparedStatementPreparationScope(
+                PreparedStatementCacheKey cacheKey, PreparedStatementPreparationScope parent)
+            {
+                CacheKey = cacheKey;
+                Parent = parent;
+            }
+
+            private PreparedStatementCacheKey CacheKey { get; }
+
+            private PreparedStatementPreparationScope Parent { get; }
+
+            public void Deactivate()
+            {
+                Interlocked.Exchange(ref _active, 0);
+            }
+
+            public static bool Contains(
+                PreparedStatementPreparationScope scope, PreparedStatementCacheKey cacheKey)
+            {
+                while (scope != null)
+                {
+                    if (Volatile.Read(ref scope._active) == 1 && scope.CacheKey.Equals(cacheKey))
+                    {
+                        return true;
+                    }
+                    scope = scope.Parent;
+                }
+                return false;
+            }
+        }
+
+        private sealed class PreparedStatementPreparation
+        {
+            private readonly HashSet<byte[]> _invalidatedIds =
+                new HashSet<byte[]>(Cluster.PreparedStatementIdComparer);
+
+            public void Invalidate(byte[] id)
+            {
+                _invalidatedIds.Add(id);
+            }
+
+            public bool WasInvalidated(byte[] id)
+            {
+                return _invalidatedIds.Contains(id);
+            }
+        }
+
+        private sealed class PreparedStatementCacheEntry
+        {
+            public PreparedStatementCacheEntry(long generation, Func<Task<PreparedStatement>> prepare)
+            {
+                _generation = generation;
+                Task = new Lazy<Task<PreparedStatement>>(
+                    prepare, LazyThreadSafetyMode.ExecutionAndPublication);
+            }
+
+            private long _generation;
+
+            public long Generation => Volatile.Read(ref _generation);
+
+            public Lazy<Task<PreparedStatement>> Task { get; }
+
+            public void UpdateGeneration(long generation)
+            {
+                Volatile.Write(ref _generation, generation);
+            }
+        }
+
+        private sealed class PreparedStatementCacheKey : IEquatable<PreparedStatementCacheKey>
+        {
+            private readonly string _cqlQuery;
+            private readonly string _keyspace;
+            private readonly bool _hasCustomPayload;
+            private readonly KeyValuePair<string, byte[]>[] _customPayload;
+
+            public PreparedStatementCacheKey(
+                string cqlQuery, string keyspace, IDictionary<string, byte[]> customPayload)
+            {
+                _cqlQuery = cqlQuery;
+                _keyspace = keyspace;
+                _hasCustomPayload = customPayload != null;
+                _customPayload = customPayload == null
+                    ? Array.Empty<KeyValuePair<string, byte[]>>()
+                    : customPayload
+                      .OrderBy(item => item.Key, StringComparer.Ordinal)
+                      .Select(item => new KeyValuePair<string, byte[]>(item.Key, item.Value?.ToArray()))
+                      .ToArray();
+            }
+
+            public bool Equals(PreparedStatementCacheKey other)
+            {
+                if (ReferenceEquals(other, null)
+                    || !string.Equals(_cqlQuery, other._cqlQuery, StringComparison.Ordinal)
+                    || !string.Equals(_keyspace, other._keyspace, StringComparison.Ordinal)
+                    || _hasCustomPayload != other._hasCustomPayload
+                    || _customPayload.Length != other._customPayload.Length)
+                {
+                    return false;
+                }
+
+                for (var i = 0; i < _customPayload.Length; i++)
+                {
+                    if (!string.Equals(_customPayload[i].Key, other._customPayload[i].Key, StringComparison.Ordinal)
+                        || !ByteArraysEqual(_customPayload[i].Value, other._customPayload[i].Value))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return Equals(obj as PreparedStatementCacheKey);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    var hashCode = _cqlQuery?.GetHashCode() ?? 0;
+                    hashCode = (hashCode * 397) ^ (_keyspace?.GetHashCode() ?? 0);
+                    hashCode = (hashCode * 397) ^ _hasCustomPayload.GetHashCode();
+                    foreach (var item in _customPayload)
+                    {
+                        hashCode = (hashCode * 397) ^ (item.Key?.GetHashCode() ?? 0);
+                        if (item.Value == null)
+                        {
+                            hashCode = (hashCode * 397) ^ -1;
+                            continue;
+                        }
+                        foreach (var value in item.Value)
+                        {
+                            hashCode = (hashCode * 397) ^ value;
+                        }
+                    }
+                    return hashCode;
+                }
+            }
+
+            public IDictionary<string, byte[]> GetCustomPayload()
+            {
+                return !_hasCustomPayload
+                    ? null
+                    : _customPayload.ToDictionary(item => item.Key, item => item.Value, StringComparer.Ordinal);
+            }
+
+            private static bool ByteArraysEqual(byte[] first, byte[] second)
+            {
+                if (ReferenceEquals(first, second))
+                {
+                    return true;
+                }
+                if (first == null || second == null || first.Length != second.Length)
+                {
+                    return false;
+                }
+                for (var i = 0; i < first.Length; i++)
+                {
+                    if (first[i] != second[i])
+                    {
+                        return false;
+                    }
+                }
+                return true;
             }
         }
     }

--- a/src/Cassandra/Connections/Connection.cs
+++ b/src/Cassandra/Connections/Connection.cs
@@ -67,7 +67,7 @@ namespace Cassandra.Connections
         private ConcurrentQueue<OperationState> _writeQueue;
 
         private volatile string _keyspace;
-        private TaskCompletionSource<bool> _keyspaceSwitchTcs;
+        private readonly SemaphoreSlim _keyspaceSwitchLock = new SemaphoreSlim(1, 1);
 
         /// <summary>
         /// Small buffer (less than 8 bytes) that is used when the next received message is smaller than 8 bytes,
@@ -817,6 +817,12 @@ namespace Cassandra.Connections
                         plainTextStream.Position = 0;
                     }
                     response = FrameParser.Parse(new Frame(header, plainTextStream, serializer, resultMetadata));
+                    if (response is ResultResponse resultResponse && resultResponse.Output is OutputSetKeyspace keyspace)
+                    {
+                        // USE changes server-side connection state. Keep the local state authoritative even when
+                        // the query was sent directly instead of through SetKeyspace().
+                        _keyspace = keyspace.Value;
+                    }
                 }
                 catch (Exception caughtException)
                 {
@@ -890,6 +896,61 @@ namespace Cassandra.Connections
         public Task<Response> Send(IRequest request)
         {
             return Send(request, Configuration.DefaultRequestOptions.ReadTimeoutMillis);
+        }
+
+        /// <inheritdoc />
+        public async Task<Response> SendWithKeyspace(IRequest request, string keyspace)
+        {
+            await _keyspaceSwitchLock.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                await SetKeyspaceCore(keyspace).ConfigureAwait(false);
+                return await Send(request).ConfigureAwait(false);
+            }
+            finally
+            {
+                _keyspaceSwitchLock.Release();
+            }
+        }
+
+        /// <inheritdoc />
+        public async Task<OperationState> SendWithKeyspace(
+            IRequest request,
+            string keyspace,
+            Func<IRequestError, Response, Task> callback,
+            int timeoutMillis)
+        {
+            await _keyspaceSwitchLock.WaitAsync().ConfigureAwait(false);
+            var lockReleased = 0;
+            Action releaseLock = () =>
+            {
+                if (Interlocked.Exchange(ref lockReleased, 1) == 0)
+                {
+                    _keyspaceSwitchLock.Release();
+                }
+            };
+
+            try
+            {
+                await SetKeyspaceCore(keyspace).ConfigureAwait(false);
+                var operation = Send(
+                    request,
+                    async (error, response) =>
+                    {
+                        // Response parsing has already updated _keyspace for USE. Let the next keyspace-sensitive
+                        // operation proceed before invoking request handling, which can itself retry.
+                        releaseLock();
+                        await callback(error, response).ConfigureAwait(false);
+                    },
+                    timeoutMillis);
+                operation?.SetCancellationHandler(releaseLock);
+                return operation;
+            }
+            catch
+            {
+                releaseLock();
+                throw;
+            }
         }
 
         /// <inheritdoc />
@@ -1073,53 +1134,28 @@ namespace Cassandra.Connections
         /// </summary>
         public async Task<bool> SetKeyspace(string value)
         {
-            if (string.IsNullOrEmpty(value))
+            await _keyspaceSwitchLock.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                return await SetKeyspaceCore(value).ConfigureAwait(false);
+            }
+            finally
+            {
+                _keyspaceSwitchLock.Release();
+            }
+        }
+
+        private async Task<bool> SetKeyspaceCore(string value)
+        {
+            if (string.IsNullOrEmpty(value) || _keyspace == value)
             {
                 return true;
             }
-            while (_keyspace != value)
-            {
-                var switchTcs = Volatile.Read(ref _keyspaceSwitchTcs);
-                if (switchTcs != null)
-                {
-                    // Is already switching
-                    await switchTcs.Task.ConfigureAwait(false);
-                    continue;
-                }
 
-                var tcs = new TaskCompletionSource<bool>();
-                switchTcs = Interlocked.CompareExchange(ref _keyspaceSwitchTcs, tcs, null);
-                if (switchTcs != null)
-                {
-                    // Is already switching
-                    await switchTcs.Task.ConfigureAwait(false);
-                    continue;
-                }
-
-                Exception sendException = null;
-
-                // CAS operation won, this is the only thread changing the keyspace
-                // but another thread might have changed it in the meantime
-                if (_keyspace != value)
-                {
-                    Connection.Logger.Info("Connection to host {0} switching to keyspace {1}", EndPoint.EndpointFriendlyName, value);
-                    var request = new QueryRequest(Serializer, $"USE \"{value}\"", QueryProtocolOptions.Default, false, null);
-                    try
-                    {
-                        await Send(request).ConfigureAwait(false);
-                        _keyspace = value;
-                    }
-                    catch (Exception ex)
-                    {
-                        sendException = ex;
-                    }
-                }
-
-                // Set the reference to null before setting the result
-                Interlocked.Exchange(ref _keyspaceSwitchTcs, null);
-                tcs.TrySet(sendException, true);
-                return await tcs.Task.ConfigureAwait(false);
-            }
+            Connection.Logger.Info("Connection to host {0} switching to keyspace {1}", EndPoint.EndpointFriendlyName, value);
+            var request = new QueryRequest(Serializer, $"USE \"{value}\"", QueryProtocolOptions.Default, false, null);
+            await Send(request).ConfigureAwait(false);
+            _keyspace = value;
             return true;
         }
 

--- a/src/Cassandra/Connections/IConnection.cs
+++ b/src/Cassandra/Connections/IConnection.cs
@@ -134,6 +134,21 @@ namespace Cassandra.Connections
         Task<Response> Send(IRequest request);
 
         /// <summary>
+        /// Sets the connection keyspace and sends the request while preventing another keyspace switch in between.
+        /// </summary>
+        Task<Response> SendWithKeyspace(IRequest request, string keyspace);
+
+        /// <summary>
+        /// Sets the connection keyspace and sends the request under the keyspace-switch lock.
+        /// The lock is held until a response or error is received.
+        /// </summary>
+        Task<OperationState> SendWithKeyspace(
+            IRequest request,
+            string keyspace,
+            Func<IRequestError, Response, Task> callback,
+            int timeoutMillis);
+
+        /// <summary>
         /// Sends a new request if possible and executes the callback when the response is parsed with the default timeout. If it is not possible it queues it up.
         /// </summary>
         OperationState Send(IRequest request, Func<IRequestError, Response, Task> callback);

--- a/src/Cassandra/ISession.cs
+++ b/src/Cassandra/ISession.cs
@@ -200,6 +200,10 @@ namespace Cassandra
         /// Prepares the provided query string.
         /// </summary>
         /// <param name="cqlQuery">cql query to prepare</param>
+        /// <remarks>
+        /// Prepared statements are cached per cluster using the query and effective keyspace. Concurrent calls
+        /// for the same statement share a single preparation attempt; failed attempts are not cached.
+        /// </remarks>
         PreparedStatement Prepare(string cqlQuery);
 
         /// <summary>
@@ -207,6 +211,9 @@ namespace Cassandra
         /// </summary>
         /// <param name="cqlQuery">cql query to prepare</param>
         /// <param name="customPayload">Custom outgoing payload to send with the prepare request</param>
+        /// <remarks>
+        /// Prepared statements with custom payloads are not cached; each call sends a separate prepare request.
+        /// </remarks>
         PreparedStatement Prepare(string cqlQuery, IDictionary<string, byte[]> customPayload);
 
         /// <summary>
@@ -214,7 +221,11 @@ namespace Cassandra
         /// </summary>
         /// <param name="cqlQuery">Cql query to prepare</param>
         /// <param name="keyspace">The keyspace to prepare this query with</param>
-        /// <remarks>Setting the keyspace parameter is only available with protocol v5 (not supported by the driver yet).</remarks>
+        /// <remarks>
+        /// Setting the keyspace parameter is only available with protocol v5 (not supported by the driver yet).
+        /// Prepared statements are cached per cluster using the query and effective keyspace. Concurrent calls
+        /// for the same statement share a single preparation attempt; failed attempts are not cached.
+        /// </remarks>
         PreparedStatement Prepare(string cqlQuery, string keyspace);
 
         /// <summary>
@@ -224,13 +235,20 @@ namespace Cassandra
         /// <param name="cqlQuery">Cql query to prepare</param>
         /// <param name="keyspace">The keyspace to prepare this query with</param>
         /// <param name="customPayload">Custom outgoing payload to send with the prepare request</param>
-        /// <remarks>Setting the keyspace parameter is only available with protocol v5 (not supported by the driver yet).</remarks>
+        /// <remarks>
+        /// Setting the keyspace parameter is only available with protocol v5 (not supported by the driver yet).
+        /// Prepared statements with custom payloads are not cached; each call sends a separate prepare request.
+        /// </remarks>
         PreparedStatement Prepare(string cqlQuery, string keyspace, IDictionary<string, byte[]> customPayload);
 
         /// <summary>
         /// Prepares the provided query string asynchronously.
         /// </summary>
         /// <param name="cqlQuery">cql query to prepare</param>
+        /// <remarks>
+        /// Prepared statements are cached per cluster using the query and effective keyspace. Concurrent calls
+        /// for the same statement share a single preparation attempt; failed attempts are not cached.
+        /// </remarks>
         Task<PreparedStatement> PrepareAsync(string cqlQuery);
 
         /// <summary>
@@ -238,6 +256,9 @@ namespace Cassandra
         /// </summary>
         /// <param name="cqlQuery">cql query to prepare</param>
         /// <param name="customPayload">Custom outgoing payload to send with the prepare request</param>
+        /// <remarks>
+        /// Prepared statements with custom payloads are not cached; each call sends a separate prepare request.
+        /// </remarks>
         Task<PreparedStatement> PrepareAsync(string cqlQuery, IDictionary<string, byte[]> customPayload);
 
         /// <summary>
@@ -245,7 +266,11 @@ namespace Cassandra
         /// </summary>
         /// <param name="cqlQuery">Cql query to prepare</param>
         /// <param name="keyspace">The keyspace to prepare this query with</param>
-        /// <remarks>Setting the keyspace parameter is only available with protocol v5 (not supported by the driver yet).</remarks>
+        /// <remarks>
+        /// Setting the keyspace parameter is only available with protocol v5 (not supported by the driver yet).
+        /// Prepared statements are cached per cluster using the query and effective keyspace. Concurrent calls
+        /// for the same statement share a single preparation attempt; failed attempts are not cached.
+        /// </remarks>
         Task<PreparedStatement> PrepareAsync(string cqlQuery, string keyspace);
 
         /// <summary>
@@ -255,7 +280,10 @@ namespace Cassandra
         /// <param name="cqlQuery">Cql query to prepare</param>
         /// <param name="keyspace">The keyspace to prepare this query with</param>
         /// <param name="customPayload">Custom outgoing payload to send with the prepare request</param>
-        /// <remarks>Setting the keyspace parameter is only available with protocol v5 (not supported by the driver yet).</remarks>
+        /// <remarks>
+        /// Setting the keyspace parameter is only available with protocol v5 (not supported by the driver yet).
+        /// Prepared statements with custom payloads are not cached; each call sends a separate prepare request.
+        /// </remarks>
         Task<PreparedStatement> PrepareAsync(string cqlQuery, string keyspace, IDictionary<string, byte[]> customPayload);
 
         /// <summary>

--- a/src/Cassandra/OperationState.cs
+++ b/src/Cassandra/OperationState.cs
@@ -46,6 +46,7 @@ namespace Cassandra
         private volatile bool _timeoutCallbackSet;
         private int _state = StateInit;
         private volatile HashedWheelTimer.ITimeout _timeout;
+        private Action _cancellationHandler;
 
         /// <summary>
         /// See docs for <see cref="IRequest.ResultMetadata"/>.
@@ -122,6 +123,7 @@ namespace Cassandra
             Func<IRequestError, Response, long, Task> callback;
             if (previousState == StateInit)
             {
+                Interlocked.Exchange(ref _cancellationHandler, null);
                 callback = Interlocked.Exchange(ref _callback, Noop);
                 var timeout = _timeout;
                 if (timeout != null)
@@ -196,6 +198,24 @@ namespace Cassandra
                 //Cancel it if it hasn't expired
                 //We should not worry about yielding OperationTimedOutExceptions when this is cancelled.
                 timeout.Cancel();
+            }
+            Interlocked.Exchange(ref _cancellationHandler, null)?.Invoke();
+        }
+
+        internal void SetCancellationHandler(Action handler)
+        {
+            if (Interlocked.CompareExchange(ref _cancellationHandler, handler, null) != null)
+            {
+                throw new InvalidOperationException("A cancellation handler has already been set.");
+            }
+            var state = Volatile.Read(ref _state);
+            if (state != StateInit)
+            {
+                var registeredHandler = Interlocked.Exchange(ref _cancellationHandler, null);
+                if (state == StateCancelled)
+                {
+                    registeredHandler?.Invoke();
+                }
             }
         }
 

--- a/src/Cassandra/Requests/IPrepareHandler.cs
+++ b/src/Cassandra/Requests/IPrepareHandler.cs
@@ -24,6 +24,9 @@ namespace Cassandra.Requests
     internal interface IPrepareHandler
     {
         Task<PreparedStatement> Prepare(
-            InternalPrepareRequest request, IInternalSession session, IEnumerator<HostShard> queryPlan);
+            InternalPrepareRequest request,
+            IInternalSession session,
+            IEnumerator<HostShard> queryPlan,
+            string sessionKeyspace);
     }
 }

--- a/src/Cassandra/Requests/PrepareHandler.cs
+++ b/src/Cassandra/Requests/PrepareHandler.cs
@@ -44,14 +44,18 @@ namespace Cassandra.Requests
         }
 
         public async Task<PreparedStatement> Prepare(
-            InternalPrepareRequest request, IInternalSession session, IEnumerator<HostShard> queryPlan)
+            InternalPrepareRequest request,
+            IInternalSession session,
+            IEnumerator<HostShard> queryPlan,
+            string sessionKeyspace)
         {
-            var infoAndObs = await CreateRequestObserverAsync(session, request).ConfigureAwait(false);
+            var infoAndObs = await CreateRequestObserverAsync(session, request, sessionKeyspace).ConfigureAwait(false);
             var observer = infoAndObs.Item2;
             var requestTrackingInfo = infoAndObs.Item1;
             try
             {
-                var prepareResult = await SendRequestToOneNode(session, queryPlan, request, observer, requestTrackingInfo).ConfigureAwait(false);
+                var prepareResult = await SendRequestToOneNode(
+                    session, queryPlan, request, observer, requestTrackingInfo, sessionKeyspace).ConfigureAwait(false);
 
                 if (session.Cluster.Configuration.QueryOptions.IsPrepareOnAllHosts())
                 {
@@ -68,23 +72,30 @@ namespace Cassandra.Requests
             }
         }
 
-        public static async Task<Tuple<SessionRequestInfo, IRequestObserver>> CreateRequestObserverAsync(IInternalSession session, InternalPrepareRequest request)
+        public static async Task<Tuple<SessionRequestInfo, IRequestObserver>> CreateRequestObserverAsync(
+            IInternalSession session, InternalPrepareRequest request, string sessionKeyspace)
         {
-            var requestTrackingInfo = new SessionRequestInfo(request, session.Keyspace);
+            var requestTrackingInfo = new SessionRequestInfo(request, sessionKeyspace);
             var observer = session.ObserverFactory.CreateRequestObserver();
             await observer.OnRequestStartAsync(requestTrackingInfo).ConfigureAwait(false);
             return new Tuple<SessionRequestInfo, IRequestObserver>(requestTrackingInfo, observer);
         }
 
         private async Task<PrepareResult> SendRequestToOneNode(
-            IInternalSession session, IEnumerator<HostShard> queryPlan, InternalPrepareRequest request, IRequestObserver observer, SessionRequestInfo info)
+            IInternalSession session,
+            IEnumerator<HostShard> queryPlan,
+            InternalPrepareRequest request,
+            IRequestObserver observer,
+            SessionRequestInfo info,
+            string sessionKeyspace)
         {
             var triedHosts = new Dictionary<IPEndPoint, Exception>();
 
             while (true)
             {
                 // It may throw a NoHostAvailableException which we should yield to the caller
-                var hostConnectionTuple = await GetNextConnection(session, queryPlan, triedHosts).ConfigureAwait(false);
+                var hostConnectionTuple = await GetNextConnection(
+                    session, queryPlan, triedHosts, sessionKeyspace).ConfigureAwait(false);
                 var connection = hostConnectionTuple.Item2;
                 var host = hostConnectionTuple.Item1;
                 var nodeRequestInfo = new NodeRequestInfo(host, info.PrepareRequest ?? new PrepareRequest(request.Query, request.Keyspace));
@@ -92,11 +103,11 @@ namespace Cassandra.Requests
                 try
                 {
                     await observer.OnNodeStartAsync(info, nodeRequestInfo).ConfigureAwait(false);
-                    var result = await connection.Send(request).ConfigureAwait(false);
+                    var result = await connection.SendWithKeyspace(request, sessionKeyspace).ConfigureAwait(false);
                     responseReceived = true;
                     var prepareResult = new PrepareResult
                     {
-                        PreparedStatement = await GetPreparedStatement(result, request, request.Keyspace ?? connection.Keyspace, session.Cluster, connection.LwtInfo()).ConfigureAwait(false),
+                        PreparedStatement = await GetPreparedStatement(result, request, request.Keyspace ?? sessionKeyspace, session.Cluster, connection.LwtInfo()).ConfigureAwait(false),
                         TriedHosts = triedHosts,
                         HostAddress = host.Address
                     };
@@ -132,12 +143,16 @@ namespace Cassandra.Requests
         }
 
         private async Task<Tuple<Host, IConnection>> GetNextConnection(
-            IInternalSession session, IEnumerator<HostShard> queryPlan, Dictionary<IPEndPoint, Exception> triedHosts)
+            IInternalSession session,
+            IEnumerator<HostShard> queryPlan,
+            Dictionary<IPEndPoint, Exception> triedHosts,
+            string sessionKeyspace)
         {
             Host host;
             while ((host = GetNextHost(queryPlan, out HostDistance distance)) != null)
             {
-                var connection = await RequestHandler.GetConnectionFromHostAsync(host, distance, session, triedHosts).ConfigureAwait(false);
+                var connection = await RequestHandler.GetConnectionFromHostWithKeyspaceAsync(
+                    host, distance, session, triedHosts, sessionKeyspace).ConfigureAwait(false);
                 if (connection != null)
                 {
                     return Tuple.Create(host, connection);

--- a/src/Cassandra/Requests/ReprepareHandler.cs
+++ b/src/Cassandra/Requests/ReprepareHandler.cs
@@ -127,7 +127,7 @@ namespace Cassandra.Requests
 
                 if (connection != null)
                 {
-                    await connection.Send(request).ConfigureAwait(false);
+                    await connection.SendWithKeyspace(request, ps.Keyspace).ConfigureAwait(false);
                     if (observer != null)
                     {
                         await observer.OnNodeSuccessAsync(sessionRequestInfo, nodeRequestInfo).ConfigureAwait(false);

--- a/src/Cassandra/Requests/RequestExecution.cs
+++ b/src/Cassandra/Requests/RequestExecution.cs
@@ -182,7 +182,19 @@ namespace Cassandra.Requests
 
             try
             {
-                _operation = _connection.Send(request, (error, response) => callback(error, response, nodeRequestInfo), timeoutMillis);
+                if (_parent.Statement is SimpleStatement statement && statement.IsKeyspaceSwitch)
+                {
+                    _operation = await _connection.SendWithKeyspace(
+                        request,
+                        _sessionRequestInfo.SessionKeyspace,
+                        (error, response) => callback(error, response, nodeRequestInfo),
+                        timeoutMillis).ConfigureAwait(false);
+                }
+                else
+                {
+                    _operation = _connection.Send(
+                        request, (error, response) => callback(error, response, nodeRequestInfo), timeoutMillis);
+                }
             }
             catch (Exception ex)
             {
@@ -664,6 +676,7 @@ namespace Cassandra.Requests
 
                     if (!outputPrepared.QueryId.SequenceEqual(originalError.UnknownId))
                     {
+                        _session.InternalCluster.InvalidatePreparedStatement(originalError.UnknownId);
                         var ex = new PreparedStatementIdMismatchException(originalError.UnknownId, outputPrepared.QueryId);
                         if (_parent.SetNodeExecutionCompleted(nodeRequestInfo.ExecutionId))
                         {

--- a/src/Cassandra/Requests/RequestHandler.cs
+++ b/src/Cassandra/Requests/RequestHandler.cs
@@ -434,17 +434,39 @@ namespace Cassandra.Requests
         internal static Task<IConnection> GetConnectionFromHostAsync(
             Host host, HostDistance distance, IInternalSession session, IDictionary<IPEndPoint, Exception> triedHosts, RoutingKey routingKey = null, int shardID = -1)
         {
-            return GetConnectionFromHostInternalAsync(host, distance, session, triedHosts, true, routingKey, shardID);
+            return GetConnectionFromHostInternalAsync(
+                host, distance, session, triedHosts, true, () => session.Keyspace, routingKey, shardID);
+        }
+
+        internal static Task<IConnection> GetConnectionFromHostWithKeyspaceAsync(
+            Host host,
+            HostDistance distance,
+            IInternalSession session,
+            IDictionary<IPEndPoint, Exception> triedHosts,
+            string keyspace,
+            RoutingKey routingKey = null,
+            int shardID = -1)
+        {
+            return GetConnectionFromHostInternalAsync(
+                host, distance, session, triedHosts, true, () => keyspace, routingKey, shardID);
         }
 
         private static async Task<IConnection> GetConnectionFromHostInternalAsync(
-            Host host, HostDistance distance, IInternalSession session, IDictionary<IPEndPoint, Exception> triedHosts, bool retry, RoutingKey routingKey, int shardID = -1)
+            Host host,
+            HostDistance distance,
+            IInternalSession session,
+            IDictionary<IPEndPoint, Exception> triedHosts,
+            bool retry,
+            Func<string> getKeyspaceFunc,
+            RoutingKey routingKey,
+            int shardID = -1)
         {
             var hostPool = session.GetOrCreateConnectionPool(host, distance);
 
             try
             {
-                return await hostPool.GetConnectionFromHostAsync(triedHosts, () => session.Keyspace, routingKey, shardID).ConfigureAwait(false);
+                return await hostPool.GetConnectionFromHostAsync(
+                    triedHosts, getKeyspaceFunc, routingKey, shardID).ConfigureAwait(false);
             }
             catch (SocketException)
             {
@@ -452,7 +474,8 @@ namespace Cassandra.Requests
                 {
                     // A socket exception on the current connection does not mean that all the pool is closed:
                     // Retry on the same host
-                    return await RequestHandler.GetConnectionFromHostInternalAsync(host, distance, session, triedHosts, false, routingKey).ConfigureAwait(false);
+                    return await RequestHandler.GetConnectionFromHostInternalAsync(
+                        host, distance, session, triedHosts, false, getKeyspaceFunc, routingKey, shardID).ConfigureAwait(false);
                 }
 
                 throw;

--- a/src/Cassandra/Session.cs
+++ b/src/Cassandra/Session.cs
@@ -139,7 +139,7 @@ namespace Cassandra
         {
             if (Keyspace != keyspace)
             {
-                Execute(new SimpleStatement(CqlQueryTools.GetUseKeyspaceCql(keyspace)));
+                Execute(new SimpleStatement(CqlQueryTools.GetUseKeyspaceCql(keyspace)).SetKeyspaceSwitch());
                 Keyspace = keyspace;
             }
         }

--- a/src/Cassandra/SessionManagement/IInternalCluster.cs
+++ b/src/Cassandra/SessionManagement/IInternalCluster.cs
@@ -35,7 +35,7 @@ namespace Cassandra.SessionManagement
         IControlConnection GetControlConnection();
 
         /// <summary>
-        /// Gets the the prepared statements cache
+        /// Gets the prepared statements indexed by server-side ID for prepare-on-up.
         /// </summary>
         ConcurrentDictionary<byte[], PreparedStatement> PreparedQueries { get; }
 
@@ -43,9 +43,14 @@ namespace Cassandra.SessionManagement
         /// Executes the prepare request on the first host selected by the load balancing policy.
         /// When <see cref="QueryOptions.IsPrepareOnAllHosts"/> is enabled, it prepares on the rest of the hosts in
         /// parallel.
-        /// In case the statement was already in the prepared statements cache, logs an warning but prepares it anyway.
+        /// In case the statement is already in the prepared statements cache, returns the cached instance.
         /// </summary>
         Task<PreparedStatement> Prepare(IInternalSession session, ISerializerManager serializerManager, InternalPrepareRequest request);
+
+        /// <summary>
+        /// Removes all cached client-side prepared statements with the provided server-side ID.
+        /// </summary>
+        void InvalidatePreparedStatement(byte[] id);
 
         IReadOnlyDictionary<IContactPoint, IEnumerable<IConnectionEndPoint>> GetResolvedEndpoints();
 

--- a/src/Cassandra/SimpleStatement.cs
+++ b/src/Cassandra/SimpleStatement.cs
@@ -33,6 +33,8 @@ namespace Cassandra
         private object[] _routingValues;
         private string _keyspace;
 
+        internal bool IsKeyspaceSwitch { get; private set; }
+
         /// <summary>
         ///  Gets the query string.
         /// </summary>
@@ -236,6 +238,12 @@ namespace Cassandra
         public SimpleStatement SetKeyspace(string name)
         {
             _keyspace = name;
+            return this;
+        }
+
+        internal SimpleStatement SetKeyspaceSwitch()
+        {
+            IsKeyspaceSwitch = true;
             return this;
         }
 


### PR DESCRIPTION
## Summary

- cache prepared statements at cluster scope before sending duplicate network requests
- key cache entries by CQL and the effective keyspace used on the wire
- coalesce concurrent prepares without custom payloads and evict failed or invalidated entries
- pin and normalize the session keyspace during preparation
- send every custom-payload prepare separately because payload semantics are request-specific
- invalidate cached requests, including in-flight entries, when reprepare reports a changed server-side ID
- document cache scope and behavior on the public prepare APIs

## Scope limitations

Cached prepare hits do not currently validate whether the calling session has been disposed. A disposed session can therefore receive a statement cached by another session with the same effective keyspace. This lifecycle contract needs broader, consistent handling across cached and uncached paths and is tracked separately in #274.

General connection keyspace selection is not atomic with ordinary request sends. A concurrent keyspace switch can therefore cause an unqualified request to execute against the wrong keyspace. This race predates this PR and requires broader request-pipeline coordination, so it is tracked separately in #277.

## Reproduction

Before this change, preparing the same query twice against a three-node Simulacron cluster increased PREPARE requests from 3 to 6. The driver returned the same object only after sending the duplicate requests and discarding the second response.

After this change, the request count remains 3, including when the same query is prepared through another session on the same cluster.

## Tests

- `dotnet test src/Cassandra.Tests/Cassandra.Tests.csproj --no-restore` (1442 passed, 4 skipped)
- `dotnet test src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj -c Release -f net9 --no-build --filter FullyQualifiedName~Cassandra.IntegrationTests.Core.PrepareSimulatorTests` (8 passed)
- added CCM-backed regression coverage for payload variants sharing an ID and recovery after an ID mismatch; these compile locally and will execute in CI, but local execution was blocked by a broken `ccm` installation (`ccmlib` was unavailable)

Fixes #271